### PR TITLE
SceneTree add UsingNodePath

### DIFF
--- a/SourceGenerators/SceneTreeExtensions/SceneTreeAttribute.cs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeAttribute.cs
@@ -8,6 +8,7 @@ namespace Godot
         public SceneTreeAttribute(
             string tscnRelativeToClassPath = null,
             bool traverseInstancedScenes = false,
+            bool usingNodePath = false,
             [CallerFilePath] string classPath = null)
         {
             SceneFile = tscnRelativeToClassPath is null
@@ -15,9 +16,11 @@ namespace Godot
                 : Path.Combine(Path.GetDirectoryName(classPath), tscnRelativeToClassPath);
 
             TraverseInstancedScenes = traverseInstancedScenes;
+            UsingNodePath = usingNodePath;
         }
 
         public string SceneFile { get; }
         public bool TraverseInstancedScenes { get; }
+        public bool UsingNodePath { get; }
     }
 }

--- a/SourceGenerators/SceneTreeExtensions/SceneTreeDataModel.cs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeDataModel.cs
@@ -6,8 +6,12 @@ namespace GodotSharp.SourceGenerators.SceneTreeExtensions
     {
         public Tree<SceneTreeNode> SceneTree { get; }
         public List<SceneTreeNode> UniqueNodes { get; }
+        public bool UsingNodePath { get; }
 
-        public SceneTreeDataModel(Compilation compilation, INamedTypeSymbol symbol, string tscnFile, bool traverseInstancedScenes) : base(symbol)
-            => (SceneTree, UniqueNodes) = SceneTreeScraper.GetNodes(compilation, tscnFile, traverseInstancedScenes);
+        public SceneTreeDataModel(Compilation compilation, INamedTypeSymbol symbol, string tscnFile, bool traverseInstancedScenes, bool usingNodePath) : base(symbol)
+        {
+            (SceneTree, UniqueNodes) = SceneTreeScraper.GetNodes(compilation, tscnFile, traverseInstancedScenes);
+            UsingNodePath = usingNodePath;
+        }
     }
 }

--- a/SourceGenerators/SceneTreeExtensions/SceneTreeSourceGenerator.cs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeSourceGenerator.cs
@@ -16,7 +16,7 @@ namespace GodotSharp.SourceGenerators.SceneTreeExtensions
             if (!File.Exists(sceneTree.SceneFile))
                 return (null, Diagnostics.SceneFileNotFound(sceneTree.SceneFile));
 
-            var model = new SceneTreeDataModel(compilation, symbol, sceneTree.SceneFile, sceneTree.TraverseInstancedScenes);
+            var model = new SceneTreeDataModel(compilation, symbol, sceneTree.SceneFile, sceneTree.TraverseInstancedScenes, sceneTree.UsingNodePath);
             Log.Debug($"--- MODEL ---\n{model.SceneTree}");
 
             var output = SceneTreeTemplate.Render(model, member => member.Name);
@@ -29,7 +29,8 @@ namespace GodotSharp.SourceGenerators.SceneTreeExtensions
                 return new(
                     (string)attribute.ConstructorArguments[0].Value,
                     (bool)attribute.ConstructorArguments[1].Value,
-                    (string)attribute.ConstructorArguments[2].Value);
+                    (bool)attribute.ConstructorArguments[2].Value,
+                    (string)attribute.ConstructorArguments[3].Value);
             }
         }
     }

--- a/SourceGenerators/SceneTreeExtensions/SceneTreeTemplate.sbncs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeTemplate.sbncs
@@ -15,11 +15,13 @@ end
 
 {{- func render_leaf(node, indent) ~}}
 
+{{~ if UsingNodePath ~}}{{NSIndent}}{{indent}}        private Godot.NodePath _{{node.Value.Name}}Path = "{{node.Value.Path}}";
+{{~ end ~}}
 {{NSIndent}}{{indent}}        [EditorBrowsable(EditorBrowsableState.Never)]
 {{NSIndent}}{{indent}}        private {{node.Value.Type}} _{{node.Value.Name}};
 
 {{NSIndent}}{{indent}}        public {{node.Value.Type}} {{node.Value.Name}} => _{{node.Value.Name}} ??=
-{{NSIndent}}{{indent}}            node.GetNodeOrNull<{{node.Value.Type}}>("{{node.Value.Path}}");
+{{NSIndent}}{{indent}}            node.GetNodeOrNull<{{node.Value.Type}}>({{ if UsingNodePath }}_{{node.Value.Name}}Path{{ else }}"{{node.Value.Path}}"{{ end }});
 {{~ end -}}
 
 {{- func render_branch(node, depth, indent) ~}}
@@ -38,11 +40,13 @@ end
 {{NSIndent}}{{indent}}            public __{{depth}}_{{node.Value.Name}}(Godot.Node node)
 {{NSIndent}}{{indent}}                => this.node = node;
 
+{{~ if UsingNodePath ~}}{{NSIndent}}{{indent}}            private Godot.NodePath _{{node.Value.Name}}Path = "{{node.Value.Path}}";
+{{~ end ~}}
 {{NSIndent}}{{indent}}            [EditorBrowsable(EditorBrowsableState.Never)]
 {{NSIndent}}{{indent}}            private {{node.Value.Type}} _{{node.Value.Name}};
 
 {{NSIndent}}{{indent}}            public {{node.Value.Type}} Get() => _{{node.Value.Name}} ??=
-{{NSIndent}}{{indent}}                node.GetNodeOrNull<{{node.Value.Type}}>("{{node.Value.Path}}");
+{{NSIndent}}{{indent}}                node.GetNodeOrNull<{{node.Value.Type}}>({{ if UsingNodePath }}_{{node.Value.Name}}Path{{ else }}"{{node.Value.Path}}"{{ end }});
 {{~
     for child in node.Children | array.filter @visible
         render_tree child depth + 1 indent + "    "


### PR DESCRIPTION
After the node is dynamically adjusted, if the node path cannot be modified, an error will be reported if you use "_" to obtain it.
There should be times when "NodePath" is needed.
![image](https://user-images.githubusercontent.com/14800320/225597800-faa11478-c4b3-4a61-998c-56eff2fceb2a.png)
![image](https://user-images.githubusercontent.com/14800320/225597917-8f223eb3-28b9-4fe4-acb2-e995e3514994.png)
