### PR TITLE
Add an implicit conversion for generated classes in SceneTree

### DIFF
--- a/SourceGenerators/SceneTreeExtensions/SceneTreeTemplate.sbncs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeTemplate.sbncs
@@ -43,6 +43,8 @@ end
 
 {{NSIndent}}{{indent}}            public {{node.Value.Type}} Get() => _{{depth}}_{{node.Value.Name}} ??=
 {{NSIndent}}{{indent}}                node.GetNodeOrNull<{{node.Value.Type}}>("{{node.Value.Path}}");
+
+{{NSIndent}}{{indent}}            public static implicit operator {{node.Value.Type}}(__{{depth}}_{{node.Value.Name}} node) => _{{depth}}_{{node.Value.Name}}.Get();
 {{~
     for child in node.Children | array.filter @visible
         render_tree child depth + 1 indent + "    "


### PR DESCRIPTION
I'm not really sure what the repercussions of this change will be, but, I didn't like using `.Get()` explicitly. I'm assuming the worst that will happen is an error when the name of a property conflicts with a node's name, at which point the user will need to cast to the correct type, or use `.Get()`