### PR TITLE
Adding #if TOOLS around generated class OnImportEditorPlugin

### DIFF
--- a/CustomGeneratorTests/CustomGeneratorTests.csproj
+++ b/CustomGeneratorTests/CustomGeneratorTests.csproj
@@ -6,6 +6,6 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="GodotSharp.SourceGenerators" Version="2.3.0" />
+    <PackageReference Include="GodotSharp.SourceGenerators" Version="2.3.1-231211-0953.Release" />
   </ItemGroup>
 </Project>

--- a/Godot 3 Tests/Godot 3 Tests.csproj
+++ b/Godot 3 Tests/Godot 3 Tests.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="GodotSharp.SourceGenerators" Version="2.3.0" />
+    <PackageReference Include="GodotSharp.SourceGenerators" Version="2.3.1-231211-0953.Release" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CustomGeneratorTests\CustomGeneratorTests.csproj" OutputItemType="analyzer" />

--- a/Godot 4 Tests/Godot 4 Tests.csproj
+++ b/Godot 4 Tests/Godot 4 Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
 	  <PackageReference Include="FluentAssertions" Version="6.12.0" />
-	  <PackageReference Include="GodotSharp.SourceGenerators" Version="2.3.0" />
+	  <PackageReference Include="GodotSharp.SourceGenerators" Version="2.3.1-231211-0953.Release" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CustomGeneratorTests\CustomGeneratorTests.csproj" OutputItemType="analyzer" />

--- a/Godot 4 Tests/TestScenes/Feature31.OnImportAttribute/OnImportTests.cs
+++ b/Godot 4 Tests/TestScenes/Feature31.OnImportAttribute/OnImportTests.cs
@@ -1,16 +1,12 @@
-using System.ComponentModel;
-using System.Linq;
-using FluentAssertions;
 using Godot;
-using Godot.Collections;
 using GodotSharp.BuildingBlocks.TestRunner;
-using static GodotTests.TestScenes.OnImportTests;
 
 namespace GodotTests.TestScenes
 {
     [SceneTree]
     public partial class OnImportTests : Node, ITest
     {
+#if TOOLS
         public enum IntEnum : int { a, b, c }
         public enum LongEnum : long { a, b, c }
 
@@ -148,8 +144,9 @@ namespace GodotTests.TestScenes
             // ok
             return Error.Ok;
         }
+#endif
     }
-
+#if TOOLS
     [Tool]
     internal partial class OnImportWithAllArgs : OnImportEditorPlugin
     {
@@ -280,4 +277,5 @@ namespace GodotTests.TestScenes
             return Error.Ok;
         }
     }
+#endif
 }

--- a/SourceGenerators/OnImportExtensions/Resources.cs
+++ b/SourceGenerators/OnImportExtensions/Resources.cs
@@ -31,7 +31,7 @@ namespace Godot
 #endif".Trim();
 
         public static readonly string OnImportEditorPlugin = @"
-#if GODOT
+#if GODOT && TOOLS
 #if NET6_0 || NET7_0 || NET8_0 // Godot 4.0 only
 using Godot.Collections;
 

--- a/SourceGenerators/SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators.csproj
@@ -36,11 +36,9 @@ C# Source Generators for use with the Godot Game Engine (supports Godot 4 and .N
 * Includes base classes/helpers to create project specific source generators
     </Description>
     <PackageReleaseNotes>
-      v.2.3.0 (prerelease)
+      v.2.3.1 (prerelease)
       - ADDED: Support for .NET 8.0
-
-      v.2.2.1
-      - ADDED: OnImport attribute (GD4 only)
+      - ADDED: OnImport attribute for editor only builds (GD4 only)
 
       v.2.1.0
       - ADDED: CodeComments attribute
@@ -81,8 +79,8 @@ C# Source Generators for use with the Godot Game Engine (supports Godot 4 and .N
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>Godot C# SourceGenerator</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>2.3.0</Version>
-    <!--<Version>2.3.0-$([System.DateTime]::Now.ToString(yyMMdd-HHmm)).$(Configuration)</Version>-->
+    <!--<Version>2.3.0</Version>-->
+    <Version>2.3.1-$([System.DateTime]::Now.ToString(yyMMdd-HHmm)).$(Configuration)</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
EditorImportPlugin is only available in Editor builds, so all import plugins will also require #if TOOLS regardless of whether they use OnImport attribute.