### PR TITLE
#43 Adding fix & tests for built in gdscript.

### DIFF
--- a/CustomGeneratorTests/CustomGeneratorTests.csproj
+++ b/CustomGeneratorTests/CustomGeneratorTests.csproj
@@ -6,7 +6,7 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="GodotSharp.SourceGenerators" Version="2.3.2" PrivateAssets="all" />
+    <PackageReference Include="GodotSharp.SourceGenerators" Version="2.3.3-240110-1949.Release" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Godot 3 Tests/Godot 3 Tests.csproj
+++ b/Godot 3 Tests/Godot 3 Tests.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="GodotSharp.SourceGenerators" Version="2.3.2" />
+    <PackageReference Include="GodotSharp.SourceGenerators" Version="2.3.3-240110-1949.Release" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CustomGeneratorTests\CustomGeneratorTests.csproj" OutputItemType="analyzer" />

--- a/Godot 3 Tests/Run.cs
+++ b/Godot 3 Tests/Run.cs
@@ -15,6 +15,7 @@ namespace GodotTests
             get
             {
                 yield return ITest.GetTest<AmbiguousTypeWithImplicitUsings>;
+                yield return ITest.GetTest<BuiltInScriptTest>;
                 yield return ITest.GetTest<CachedNodes>;
                 yield return ITest.GetTest<EditableChildrenTest>;
                 yield return ITest.GetTest<EditableChildrenWithTraversalTest>;

--- a/Godot 3 Tests/TestScenes/Issue43.BuiltInScript/BuiltInScriptTest.cs
+++ b/Godot 3 Tests/TestScenes/Issue43.BuiltInScript/BuiltInScriptTest.cs
@@ -1,0 +1,14 @@
+using Godot;
+using GodotSharp.BuildingBlocks.TestRunner;
+
+namespace GodotTests.TestScenes
+{
+    [SceneTree]
+    public partial class BuiltInScriptTest : Node, ITest
+    {
+        void ITest.InitTests()
+        {
+            // If it compiles, test passes
+        }
+    }
+}

--- a/Godot 3 Tests/TestScenes/Issue43.BuiltInScript/BuiltInScriptTest.tscn
+++ b/Godot 3 Tests/TestScenes/Issue43.BuiltInScript/BuiltInScriptTest.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://TestScenes/Issue43.BuiltInScript/BuiltInScriptTest.cs" type="Script" id=1]
+
+[sub_resource type="GDScript" id=1]
+resource_name = "BuiltInScript"
+script/source = "extends Node
+
+
+# Declare member variables here. Examples:
+# var a = 2
+# var b = \"text\"
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+    pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+#func _process(delta):
+#    pass
+"
+
+[node name="Root" type="Node"]
+script = ExtResource( 1 )
+
+[node name="Node" type="Node" parent="."]
+script = SubResource( 1 )

--- a/Godot 4 Tests/Godot 4 Tests.csproj
+++ b/Godot 4 Tests/Godot 4 Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Godot.NET.Sdk/4.2.0">
+﻿<Project Sdk="Godot.NET.Sdk/4.3.0-dev.1">
   <PropertyGroup>
     <LangVersion>preview</LangVersion>
     <TargetFramework>net8.0</TargetFramework>
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="GodotSharp.SourceGenerators" Version="2.3.2" />
+    <PackageReference Include="GodotSharp.SourceGenerators" Version="2.3.3-240110-1949.Release" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CustomGeneratorTests\CustomGeneratorTests.csproj" OutputItemType="analyzer" />

--- a/Godot 4 Tests/Run.cs
+++ b/Godot 4 Tests/Run.cs
@@ -15,6 +15,7 @@ namespace GodotTests
             get
             {
                 yield return ITest.GetTest<AmbiguousTypeWithImplicitUsings>;
+                yield return ITest.GetTest<BuiltInScriptTest>;
                 yield return ITest.GetTest<CachedNodes>;
                 yield return ITest.GetTest<EditableChildrenTest>;
                 yield return ITest.GetTest<EditableChildrenWithTraversalTest>;

--- a/Godot 4 Tests/TestScenes/Issue43.BuiltInScript/BuiltInScriptTest.cs
+++ b/Godot 4 Tests/TestScenes/Issue43.BuiltInScript/BuiltInScriptTest.cs
@@ -1,0 +1,14 @@
+using Godot;
+using GodotSharp.BuildingBlocks.TestRunner;
+
+namespace GodotTests.TestScenes
+{
+    [SceneTree]
+    public partial class BuiltInScriptTest : Node, ITest
+    {
+        void ITest.InitTests()
+        {
+            // If it compiles, test passes
+        }
+    }
+}

--- a/Godot 4 Tests/TestScenes/Issue43.BuiltInScript/BuiltInScriptTest.tscn
+++ b/Godot 4 Tests/TestScenes/Issue43.BuiltInScript/BuiltInScriptTest.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=3 format=3 uid="uid://g1y3gy2wigdb"]
+
+[ext_resource type="Script" path="res://TestScenes/Issue43.BuiltInScript/BuiltInScriptTest.cs" id="1"]
+
+[sub_resource type="GDScript" id="1"]
+resource_name = "BuiltInScript"
+script/source = "extends Node
+
+
+# Declare member variables here. Examples:
+# var a = 2
+# var b = \"text\"
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+    pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+#func _process(delta):
+#    pass
+"
+
+[node name="Root" type="Node"]
+script = ExtResource("1")
+
+[node name="Node" type="Node" parent="."]
+script = SubResource("1")

--- a/Godot 4 Tests/project.godot
+++ b/Godot 4 Tests/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Godot 4 Tests"
 run/main_scene="res://Run.tscn"
-config/features=PackedStringArray("4.2", "C#")
+config/features=PackedStringArray("4.3", "C#")
 
 [dotnet]
 

--- a/SourceGenerators/SceneTreeExtensions/SceneTreeScraper.cs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeScraper.cs
@@ -17,7 +17,7 @@ namespace GodotSharp.SourceGenerators.SceneTreeExtensions
         private static readonly Regex ResPathRegex = new(ResPathRegexStr, RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
         private static string _resPath = null;
-        private static readonly Dictionary<string, Tree<SceneTreeNode>> sceneTreeCache = new();
+        private static readonly Dictionary<string, Tree<SceneTreeNode>> sceneTreeCache = [];
 
         public static (Tree<SceneTreeNode> SceneTree, List<SceneTreeNode> UniqueNodes) GetNodes(Compilation compilation, string tscnFile, bool traverseInstancedScenes)
         {
@@ -27,7 +27,7 @@ namespace GodotSharp.SourceGenerators.SceneTreeExtensions
             var valueMatch = false;
             SceneTreeNode curNode = null;
             Tree<SceneTreeNode> sceneTree = null;
-            List<SceneTreeNode> uniqueNodes = new();
+            List<SceneTreeNode> uniqueNodes = [];
             var resources = new Dictionary<string, string>();
             var nodeLookup = new Dictionary<string, TreeNode<SceneTreeNode>>();
 
@@ -35,14 +35,13 @@ namespace GodotSharp.SourceGenerators.SceneTreeExtensions
             {
                 Log.Debug($"Line: {line}");
 
-                Match match = null;
                 if (line is "") valueMatch = false;
                 else if (valueMatch) ValueMatch();
                 else SectionMatch();
 
                 void SectionMatch()
                 {
-                    match = SectionRegex.Match(line);
+                    var match = SectionRegex.Match(line);
                     if (!match.Success) return;
                     Log.Debug($" - Section {SectionRegex.GetGroupsAsStr(match)}");
                     var name = match.Groups["Name"].Value;
@@ -261,7 +260,7 @@ namespace GodotSharp.SourceGenerators.SceneTreeExtensions
 
                 void ValueMatch()
                 {
-                    match = ValueRegex.Match(line);
+                    var match = ValueRegex.Match(line);
                     if (!match.Success) return;
                     Log.Debug($" - Value {ValueRegex.GetGroupsAsStr(match)}");
                     var key = match.Groups["Key"].Value;
@@ -276,7 +275,9 @@ namespace GodotSharp.SourceGenerators.SceneTreeExtensions
                     void ScriptMatch()
                     {
                         if (value is "null") return;
-                        var resourceId = ResIdRegex.Match(value).Groups["Id"].Value;
+                        var match = ResIdRegex.Match(value);
+                        if (!match.Success) return;
+                        var resourceId = match.Groups["Id"].Value;
                         Log.Debug($" - ResourceId: {resourceId}");
                         var resource = resources[resourceId];
                         var name = Path.GetFileNameWithoutExtension(resource);

--- a/SourceGenerators/SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators.csproj
@@ -44,7 +44,7 @@
 		* Includes base classes/helpers to create project specific source generators
 	</Description>
     <PackageReleaseNotes>
-		v.2.3.2
+		v.2.3.3
 		- ADDED: Support for .NET 8.0
 		- ADDED: Nested InputMap entries
 		- ADDED: OnImport attribute for editor only builds (GD4 only)
@@ -88,8 +88,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>Godot C# SourceGenerator</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>2.3.2</Version>
-    <!--<Version>2.3.2-$([System.DateTime]::Now.ToString(yyMMdd-HHmm)).$(Configuration)</Version>-->
+    <!--<Version>2.3.2</Version>-->
+    <Version>2.3.3-$([System.DateTime]::Now.ToString(yyMMdd-HHmm)).$(Configuration)</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
As stated, a built in script uses SubResource rather than ExtResource, so won't match.