### PR TITLE
Deduplicate scene tree classes

### DIFF
--- a/SourceGenerators/CodeCommentsExtensions/CodeCommentsSourceGenerator.cs
+++ b/SourceGenerators/CodeCommentsExtensions/CodeCommentsSourceGenerator.cs
@@ -10,7 +10,12 @@ namespace GodotSharp.SourceGenerators.CodeCommentsExtensions
         private static Template _codeCommentsTemplate;
         private static Template CodeCommentsTemplate => _codeCommentsTemplate ??= Template.Parse(Resources.CodeCommentsTemplate);
 
-        protected override (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, INamedTypeSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
+        protected override CodeGenerationResult GenerateCode(
+            Compilation compilation,
+            SyntaxNode node,
+            INamedTypeSymbol symbol,
+            AttributeData attribute,
+            AnalyzerConfigOptions options)
         {
             var model = new CodeCommentsDataModel(symbol, node, ReconstructAttribute().Strip);
             Log.Debug($"--- MODEL ---\n{model}\n");
@@ -18,7 +23,7 @@ namespace GodotSharp.SourceGenerators.CodeCommentsExtensions
             var output = CodeCommentsTemplate.Render(model, member => member.Name);
             Log.Debug($"--- OUTPUT ---\n{output}<END>\n");
 
-            return (output, null);
+            return new CodeGenerationResult.Success(output);
 
             Godot.CodeCommentsAttribute ReconstructAttribute()
                 => new((string)attribute.ConstructorArguments[0].Value);

--- a/SourceGenerators/CodeDependency.cs
+++ b/SourceGenerators/CodeDependency.cs
@@ -1,0 +1,10 @@
+namespace GodotSharp.SourceGenerators;
+
+// We rely on the record equality here
+public abstract record CodeDependency
+{
+    public record SceneTree(string TscnFileName, bool TraverseInstancedScenes) : CodeDependency
+    {
+        public string ClassName { get; } = TscnFileName;
+    }
+}

--- a/SourceGenerators/CodeDependency.cs
+++ b/SourceGenerators/CodeDependency.cs
@@ -5,6 +5,7 @@ public abstract record CodeDependency
 {
     public record SceneTree(string TscnFileName, bool TraverseInstancedScenes) : CodeDependency
     {
-        public string ClassName { get; } = TscnFileName;
+        public string ClassName { get; } = $"_{Path.GetFileNameWithoutExtension(TscnFileName).ToSafeName()}";
+        public string Namespace { get; } = "GodotSharp.SourceGenerators.SceneTreeExtensions";
     }
 }

--- a/SourceGenerators/CodeGenerationResult.cs
+++ b/SourceGenerators/CodeGenerationResult.cs
@@ -1,0 +1,11 @@
+namespace GodotSharp.SourceGenerators;
+
+public abstract record CodeGenerationResult
+{
+    public record Success(string Code, IEnumerable<CodeDependency> Dependencies) : CodeGenerationResult
+    {
+        public Success(string Code) : this(Code, Enumerable.Empty<CodeDependency>()) {}
+    }
+
+    public record Error(DiagnosticDetail Detail) : CodeGenerationResult;
+}

--- a/SourceGenerators/DependencyResolver.cs
+++ b/SourceGenerators/DependencyResolver.cs
@@ -1,0 +1,21 @@
+using GodotSharp.SourceGenerators.SceneTreeExtensions;
+using Microsoft.CodeAnalysis;
+
+namespace GodotSharp.SourceGenerators;
+
+public class DependencyResolver
+{
+    public IEnumerable<CodeDependency> ResolveDependency(
+        SourceProductionContext context,
+        Compilation compilation,
+        CodeDependency dependency)
+    {
+        switch (dependency)
+        {
+            case CodeDependency.SceneTree sceneTree:
+                return new SceneTreeSourceGenerator().GenerateSceneTree(context, compilation, sceneTree);
+            default:
+                throw new InvalidOperationException($"Unresolved dependency of type {dependency.GetType().Name}.");
+        }
+    }
+}

--- a/SourceGenerators/GodotNotifyExtensions/GodotNotifySourceGenerator.cs
+++ b/SourceGenerators/GodotNotifyExtensions/GodotNotifySourceGenerator.cs
@@ -10,7 +10,12 @@ namespace GodotSharp.SourceGenerators.GodotNotifyExtensions
         private static Template _godotNotifyTemplate;
         private static Template GodotNotifyTemplate => _godotNotifyTemplate ??= Template.Parse(Resources.GodotNotifyTemplate);
 
-        protected override (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, IPropertySymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
+        protected override CodeGenerationResult GenerateCode(
+            Compilation compilation,
+            SyntaxNode node,
+            IPropertySymbol symbol,
+            AttributeData attribute,
+            AnalyzerConfigOptions options)
         {
             var model = new GodotNotifyDataModel(symbol);
             Log.Debug($"--- MODEL ---\n{model}\n");
@@ -18,7 +23,7 @@ namespace GodotSharp.SourceGenerators.GodotNotifyExtensions
             var output = GodotNotifyTemplate.Render(model, member => member.Name);
             Log.Debug($"--- OUTPUT ---\n{output}<END>\n");
 
-            return (output, null);
+            return new CodeGenerationResult.Success(output);
         }
     }
 }

--- a/SourceGenerators/GodotOverrideExtensions/GodotOverrideSourceGenerator.cs
+++ b/SourceGenerators/GodotOverrideExtensions/GodotOverrideSourceGenerator.cs
@@ -10,7 +10,7 @@ namespace GodotSharp.SourceGenerators.GodotOverrideExtensions
         private static Template _godotOverrideTemplate;
         private static Template GodotOverrideTemplate => _godotOverrideTemplate ??= Template.Parse(Resources.GodotOverrideTemplate);
 
-        protected override (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, IMethodSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
+        protected override CodeGenerationResult GenerateCode(Compilation compilation, SyntaxNode node, IMethodSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
         {
             var model = new GodotOverrideDataModel(symbol, ReconstructAttribute().Replace);
             Log.Debug($"--- MODEL ---\n{model}\n");
@@ -18,7 +18,7 @@ namespace GodotSharp.SourceGenerators.GodotOverrideExtensions
             var output = GodotOverrideTemplate.Render(model, member => member.Name);
             Log.Debug($"--- OUTPUT ---\n{output}<END>\n");
 
-            return (output, null);
+            return new CodeGenerationResult.Success(output);
 
             Godot.GodotOverrideAttribute ReconstructAttribute()
                 => new((bool)attribute.ConstructorArguments[0].Value);

--- a/SourceGenerators/InputMapExtensions/InputMapSourceGenerator.cs
+++ b/SourceGenerators/InputMapExtensions/InputMapSourceGenerator.cs
@@ -10,7 +10,12 @@ namespace GodotSharp.SourceGenerators.InputMapExtensions
         private static Template _inputMapTemplate;
         private static Template InputMapTemplate => _inputMapTemplate ??= Template.Parse(Resources.InputMapTemplate);
 
-        protected override (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, INamedTypeSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
+        protected override CodeGenerationResult GenerateCode(
+            Compilation compilation,
+            SyntaxNode node,
+            INamedTypeSymbol symbol,
+            AttributeData attribute,
+            AnalyzerConfigOptions options)
         {
             var model = new InputMapDataModel(symbol, ReconstructAttribute().ClassPath, options.TryGetGodotProjectDir());
             Log.Debug($"--- MODEL ---\n{model}\n");
@@ -18,7 +23,7 @@ namespace GodotSharp.SourceGenerators.InputMapExtensions
             var output = InputMapTemplate.Render(model, member => member.Name);
             Log.Debug($"--- OUTPUT ---\n{output}<END>\n");
 
-            return (output, null);
+            return new CodeGenerationResult.Success(output);
 
             Godot.InputMapAttribute ReconstructAttribute()
                 => new((string)attribute.ConstructorArguments[0].Value);

--- a/SourceGenerators/LayerNamesExtensions/LayerNamesSourceGenerator.cs
+++ b/SourceGenerators/LayerNamesExtensions/LayerNamesSourceGenerator.cs
@@ -10,7 +10,12 @@ namespace GodotSharp.SourceGenerators.LayerNamesExtensions
         private static Template _layerNamesTemplate;
         private static Template LayerNamesTemplate => _layerNamesTemplate ??= Template.Parse(Resources.LayerNamesTemplate);
 
-        protected override (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, INamedTypeSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
+        protected override CodeGenerationResult GenerateCode(
+            Compilation compilation,
+            SyntaxNode node,
+            INamedTypeSymbol symbol,
+            AttributeData attribute,
+            AnalyzerConfigOptions options)
         {
             var model = new LayerNamesDataModel(symbol, ReconstructAttribute().ClassPath, options.TryGetGodotProjectDir());
             Log.Debug($"--- MODEL ---\n{model}\n");
@@ -18,7 +23,7 @@ namespace GodotSharp.SourceGenerators.LayerNamesExtensions
             var output = LayerNamesTemplate.Render(model, member => member.Name);
             Log.Debug($"--- OUTPUT ---\n{output}<END>\n");
 
-            return (output, null);
+            return new CodeGenerationResult.Success(output);
 
             Godot.LayerNamesAttribute ReconstructAttribute()
                 => new((string)attribute.ConstructorArguments[0].Value);

--- a/SourceGenerators/OnImportExtensions/OnImportSourceGenerator.cs
+++ b/SourceGenerators/OnImportExtensions/OnImportSourceGenerator.cs
@@ -19,7 +19,7 @@ namespace GodotSharp.SourceGenerators.OnImportExtensions
             }
         }
 
-        protected override (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, IMethodSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
+        protected override CodeGenerationResult GenerateCode(Compilation compilation, SyntaxNode node, IMethodSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
         {
             var model = new OnImportDataModel(symbol, ReconstructAttribute());
             Log.Debug($"--- MODEL ---\n{model}\n");
@@ -27,7 +27,7 @@ namespace GodotSharp.SourceGenerators.OnImportExtensions
             var output = OnImportTemplate.Render(model, member => member.Name);
             Log.Debug($"--- OUTPUT ---\n{output}<END>\n");
 
-            return (output, null);
+            return new CodeGenerationResult.Success(output);
 
             Godot.OnImportAttribute ReconstructAttribute() => new
             (

--- a/SourceGenerators/OnInstantiateExtensions/OnInstantiateSourceGenerator.cs
+++ b/SourceGenerators/OnInstantiateExtensions/OnInstantiateSourceGenerator.cs
@@ -10,7 +10,7 @@ namespace GodotSharp.SourceGenerators.OnInstantiateExtensions
         private static Template _onInstantiateTemplate;
         private static Template OnInstantiateTemplate => _onInstantiateTemplate ??= Template.Parse(Resources.OnInstantiateTemplate);
 
-        protected override (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, IMethodSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
+        protected override CodeGenerationResult GenerateCode(Compilation compilation, SyntaxNode node, IMethodSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
         {
             var model = new OnInstantiateDataModel(compilation, symbol, node, ReconstructAttribute().ConstructorScope, options.TryGetGodotProjectDir());
             Log.Debug($"--- MODEL ---\n{model}\n");
@@ -18,7 +18,7 @@ namespace GodotSharp.SourceGenerators.OnInstantiateExtensions
             var output = OnInstantiateTemplate.Render(model, member => member.Name);
             Log.Debug($"--- OUTPUT ---\n{output}<END>\n");
 
-            return (output, null);
+            return new CodeGenerationResult.Success(output);
 
             Godot.OnInstantiateAttribute ReconstructAttribute()
                 => new((string)attribute.ConstructorArguments[0].Value);

--- a/SourceGenerators/SceneTreeExtensions/Resources.cs
+++ b/SourceGenerators/SceneTreeExtensions/Resources.cs
@@ -5,6 +5,8 @@ namespace GodotSharp.SourceGenerators.SceneTreeExtensions
     internal static class Resources
     {
         private const string sceneTreeTemplate = "GodotSharp.SourceGenerators.SceneTreeExtensions.SceneTreeTemplate.sbncs";
+        private const string sceneTreeNodeTemplate = "GodotSharp.SourceGenerators.SceneTreeExtensions.SceneTreeNodeTemplate.sbncs";
         public static readonly string SceneTreeTemplate = Assembly.GetExecutingAssembly().GetEmbeddedResource(sceneTreeTemplate);
+        public static readonly string SceneTreeNodeTemplate = Assembly.GetExecutingAssembly().GetEmbeddedResource(sceneTreeNodeTemplate);
     }
 }

--- a/SourceGenerators/SceneTreeExtensions/SceneTreeDataModel.cs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeDataModel.cs
@@ -4,17 +4,21 @@ namespace GodotSharp.SourceGenerators.SceneTreeExtensions
 {
     internal class SceneTreeDataModel
     {
-        public string SceneTreeClassName { get; }
+        public string ClassName { get; }
+        public string Namespace { get; }
         public Tree<SceneTreeNode> SceneTree { get; }
         public List<SceneTreeNode> UniqueNodes { get; }
 
         public SceneTreeDataModel(
             Compilation compilation,
-            string tscnFile,
-            bool traverseInstancedScenes)
+            CodeDependency.SceneTree sceneTree)
         {
-            SceneTreeClassName = tscnFile;
-            (SceneTree, UniqueNodes) = SceneTreeScraper.GetNodes(compilation, tscnFile, traverseInstancedScenes);
+            ClassName = sceneTree.ClassName;
+            Namespace = sceneTree.Namespace;
+            (SceneTree, UniqueNodes) = SceneTreeScraper.GetNodes(
+                compilation,
+                sceneTree.TscnFileName,
+                sceneTree.TraverseInstancedScenes);
         }
 
         public override string ToString()
@@ -23,8 +27,9 @@ namespace GodotSharp.SourceGenerators.SceneTreeExtensions
 
             IEnumerable<string> Parts()
             {
-                yield return SceneTree.ToString().TrimEnd();
-                yield return $"SceneTreeClassname: {SceneTreeClassName}";
+                yield return $"SceneTree: {SceneTree.ToString().TrimEnd()}";
+                yield return $"Classname: {ClassName}";
+                yield return $"Namespace: {Namespace}";
 
                 if (UniqueNodes.Any())
                     yield return $"\nUniqueNodes:\n - {string.Join("\n - ", UniqueNodes)}";

--- a/SourceGenerators/SceneTreeExtensions/SceneTreeDataModel.cs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeDataModel.cs
@@ -2,27 +2,29 @@
 
 namespace GodotSharp.SourceGenerators.SceneTreeExtensions
 {
-    internal class SceneTreeDataModel : ClassDataModel
+    internal class SceneTreeDataModel
     {
+        public string SceneTreeClassName { get; }
         public Tree<SceneTreeNode> SceneTree { get; }
         public List<SceneTreeNode> UniqueNodes { get; }
-        public string TscnFile { get; }
 
-        public SceneTreeDataModel(Compilation compilation, INamedTypeSymbol symbol, string tscnFile,
-            bool traverseInstancedScenes) : base(symbol)
+        public SceneTreeDataModel(
+            Compilation compilation,
+            string tscnFile,
+            bool traverseInstancedScenes)
         {
-            TscnFile = $"res://{tscnFile[(GD.GetProjectRoot(tscnFile).Length+1)..]}";
-            (SceneTree, UniqueNodes) =
-                SceneTreeScraper.GetNodes(compilation, tscnFile, traverseInstancedScenes);
+            SceneTreeClassName = tscnFile;
+            (SceneTree, UniqueNodes) = SceneTreeScraper.GetNodes(compilation, tscnFile, traverseInstancedScenes);
         }
 
-        protected override string Str()
+        public override string ToString()
         {
             return string.Join("\n", Parts());
 
             IEnumerable<string> Parts()
             {
                 yield return SceneTree.ToString().TrimEnd();
+                yield return $"SceneTreeClassname: {SceneTreeClassName}";
 
                 if (UniqueNodes.Any())
                     yield return $"\nUniqueNodes:\n - {string.Join("\n - ", UniqueNodes)}";

--- a/SourceGenerators/SceneTreeExtensions/SceneTreeNodeDataModel.cs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeNodeDataModel.cs
@@ -5,7 +5,7 @@ namespace GodotSharp.SourceGenerators.SceneTreeExtensions;
 internal class SceneTreeNodeDataModel(INamedTypeSymbol symbol, CodeDependency.SceneTree tree)
     : ClassDataModel(symbol)
 {
-    public string SceneTreeClassName { get; } = tree.ClassName;
+    public string SceneTreeClassName { get; } = $"{tree.Namespace}.{tree.ClassName}";
     public string TscnFile { get; } = $"res://{tree.TscnFileName[(GD.GetProjectRoot(tree.TscnFileName).Length+1)..]}";
 
     protected override string Str() => $"SceneTreeClassName: {SceneTreeClassName}";

--- a/SourceGenerators/SceneTreeExtensions/SceneTreeNodeDataModel.cs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeNodeDataModel.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace GodotSharp.SourceGenerators.SceneTreeExtensions;
+
+internal class SceneTreeNodeDataModel(INamedTypeSymbol symbol, CodeDependency.SceneTree tree)
+    : ClassDataModel(symbol)
+{
+    public string SceneTreeClassName { get; } = tree.ClassName;
+    public string TscnFile { get; } = $"res://{tree.TscnFileName[(GD.GetProjectRoot(tree.TscnFileName).Length+1)..]}";
+
+    protected override string Str() => $"SceneTreeClassName: {SceneTreeClassName}";
+}

--- a/SourceGenerators/SceneTreeExtensions/SceneTreeNodeSourceGenerator.cs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeNodeSourceGenerator.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Scriban;
+
+namespace GodotSharp.SourceGenerators.SceneTreeExtensions
+{
+    [Generator]
+    internal class SceneTreeNodeSourceGenerator : SourceGeneratorForDeclaredTypeWithAttribute<Godot.SceneTreeAttribute>
+    {
+        private static Template SceneTreeNodeTemplate { get; } = Template.Parse(Resources.SceneTreeNodeTemplate);
+
+        protected override CodeGenerationResult GenerateCode(
+            Compilation compilation,
+            SyntaxNode node,
+            INamedTypeSymbol symbol,
+            AttributeData attribute,
+            AnalyzerConfigOptions options)
+        {
+            var sceneTree = ReconstructAttribute();
+
+            if (!File.Exists(sceneTree.SceneFile))
+                return new CodeGenerationResult.Error(Diagnostics.SceneFileNotFound(sceneTree.SceneFile));
+
+            var sceneTreeDependency = new CodeDependency.SceneTree(
+                sceneTree.SceneFile,
+                sceneTree.TraverseInstancedScenes);
+            var model = new SceneTreeNodeDataModel(symbol, sceneTreeDependency);
+            Log.Debug($"--- MODEL ---\n{model}\n");
+
+            var output = SceneTreeNodeTemplate.Render(model, member => member.Name);
+            Log.Debug($"--- OUTPUT ---\n{output}<END>\n");
+
+            return new CodeGenerationResult.Success(output, Dependencies: [sceneTreeDependency]);
+
+            Godot.SceneTreeAttribute ReconstructAttribute()
+            {
+                return new(
+                    (string)attribute.ConstructorArguments[0].Value,
+                    (bool)attribute.ConstructorArguments[1].Value,
+                    (string)attribute.ConstructorArguments[2].Value);
+            }
+        }
+    }
+}

--- a/SourceGenerators/SceneTreeExtensions/SceneTreeNodeTemplate.sbncs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeNodeTemplate.sbncs
@@ -1,0 +1,46 @@
+﻿{{-
+func visible(node)
+    ret node.Value.Visible
+end
+-}}
+
+{{-
+func wrapWithQuotes
+    ret $'"{$0}"'
+end
+-}}
+
+using System.ComponentModel;
+using GodotSharp.SourceGenerators.SceneTreeExtensions;
+
+{{~NSOpen~}}
+{{NSIndent}}partial class {{ClassName}}
+{{NSIndent}}{
+{{NSIndent}}    [EditorBrowsable(EditorBrowsableState.Never)]
+{{NSIndent}}    private {{SceneTreeClassName}} _sceneTree;
+
+{{NSIndent}}    private {{SceneTreeClassName}} _ => _sceneTree ??= new(GetSceneRoot());
+
+{{NSIndent}}    private Godot.Node GetSceneRoot()
+{{NSIndent}}    {
+{{NSIndent}}        Godot.Node sceneRootEstimate = this;
+{{NSIndent}}        while (true)
+{{NSIndent}}        {
+{{NSIndent}}            if (sceneRootEstimate.SceneFilePath == "{{TscnFile}}")
+{{NSIndent}}            {
+{{NSIndent}}                return sceneRootEstimate;
+{{NSIndent}}            }
+{{NSIndent}}
+{{NSIndent}}            if (sceneRootEstimate.GetParent() is not { } newSceneRootEstimate)
+{{NSIndent}}            {
+{{NSIndent}}                Throw($"Expected {sceneRootEstimate} to have a parent.");
+{{NSIndent}}            }
+{{NSIndent}}            sceneRootEstimate = newSceneRootEstimate;
+{{NSIndent}}        }
+
+{{NSIndent}}        static void Throw(string message) {
+{{NSIndent}}            throw new System.InvalidOperationException($"Could not find root of scene {{ TscnFile }} in the instantiated tree. {message} This error might be caused by using {{ClassName}} outside of {{TscnFile}}.");
+{{NSIndent}}        }
+{{NSIndent}}    }
+{{NSIndent}}}
+{{~NSClose~}}

--- a/SourceGenerators/SceneTreeExtensions/SceneTreeSourceGenerator.cs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeSourceGenerator.cs
@@ -12,16 +12,13 @@ public class SceneTreeSourceGenerator
         Compilation compilation,
         CodeDependency.SceneTree sceneTree)
     {
-        var model = new SceneTreeDataModel(
-            compilation,
-            sceneTree.TscnFileName,
-            sceneTree.TraverseInstancedScenes);
+        var model = new SceneTreeDataModel(compilation, sceneTree);
         Log.Debug($"--- MODEL ---\n{model}\n");
 
         var output = SceneTreeTemplate.Render(model, member => member.Name);
         Log.Debug($"--- OUTPUT ---\n{output}<END>\n");
 
-        context.AddSource(sceneTree.ClassName+".g.cs", output);
+        context.AddSource(sceneTree.ClassName + ".g.cs", output);
 
         return [];
     }

--- a/SourceGenerators/SceneTreeExtensions/SceneTreeTemplate.sbncs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeTemplate.sbncs
@@ -4,60 +4,54 @@ func visible(node)
 end
 -}}
 
-{{-
-func wrapWithQuotes
-    ret $'"{$0}"'
-end
--}}
-
 {{- func render_unique(node) ~}}
-{{NSIndent}}    [EditorBrowsable(EditorBrowsableState.Never)]
-{{NSIndent}}    private {{node.Type}} _{{node.Name}};
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        private {{node.Type}} _{{node.Name}};
 
-{{NSIndent}}    public {{node.Type}} {{node.Name}} => _{{node.Name}} ??=
-{{NSIndent}}        GetNodeOrNull<{{node.Type}}>("%{{node.Path | string.split '/' | array.last}}");
+        public {{node.Type}} {{node.Name}} => _{{node.Name}} ??=
+            GetNodeOrNull<{{node.Type}}>("%{{node.Path | string.split '/' | array.last}}");
 
 {{~ end -}}
 
 {{- func render_leaf(node, indent) ~}}
 
-{{NSIndent}}{{indent}}        [EditorBrowsable(EditorBrowsableState.Never)]
-{{NSIndent}}{{indent}}        private {{node.Value.Type}} _{{node.Value.Name}};
+{{indent}}            [EditorBrowsable(EditorBrowsableState.Never)]
+{{indent}}            private {{node.Value.Type}} _{{node.Value.Name}};
 
-{{NSIndent}}{{indent}}        public {{node.Value.Type}} {{node.Value.Name}} => _{{node.Value.Name}} ??=
-{{NSIndent}}{{indent}}            node.GetNodeOrNull<{{node.Value.Type}}>("{{node.Value.Path}}");
+{{indent}}            public {{node.Value.Type}} {{node.Value.Name}} => _{{node.Value.Name}} ??=
+{{indent}}                node.GetNodeOrNull<{{node.Value.Type}}>("{{node.Value.Path}}");
 {{~ end -}}
 
 {{- func render_branch(node, depth, indent) ~}}
 
-{{NSIndent}}{{indent}}        [EditorBrowsable(EditorBrowsableState.Never)]
-{{NSIndent}}{{indent}}        private __{{depth}}_{{node.Value.Name}} _{{depth}}_{{node.Value.Name}};
+{{indent}}            [EditorBrowsable(EditorBrowsableState.Never)]
+{{indent}}            private __{{depth}}_{{node.Value.Name}} _{{depth}}_{{node.Value.Name}};
 
-{{NSIndent}}{{indent}}        public __{{depth}}_{{node.Value.Name}} {{node.Value.Name}}
-{{NSIndent}}{{indent}}            => _{{depth}}_{{node.Value.Name}} ??= new(node);
+{{indent}}            public __{{depth}}_{{node.Value.Name}} {{node.Value.Name}}
+{{indent}}                => _{{depth}}_{{node.Value.Name}} ??= new(node);
 
-{{NSIndent}}{{indent}}        [EditorBrowsable(EditorBrowsableState.Never)]
-{{NSIndent}}{{indent}}        public class __{{depth}}_{{node.Value.Name}}
-{{NSIndent}}{{indent}}        {
-{{NSIndent}}{{indent}}            private readonly Godot.Node node;
+{{indent}}            [EditorBrowsable(EditorBrowsableState.Never)]
+{{indent}}            public class __{{depth}}_{{node.Value.Name}}
+{{indent}}            {
+{{indent}}                private readonly Godot.Node node;
 
-{{NSIndent}}{{indent}}            public __{{depth}}_{{node.Value.Name}}(Godot.Node node)
-{{NSIndent}}{{indent}}                => this.node = node;
+{{indent}}                public __{{depth}}_{{node.Value.Name}}(Godot.Node node)
+{{indent}}                    => this.node = node;
 
-{{NSIndent}}{{indent}}            [EditorBrowsable(EditorBrowsableState.Never)]
-{{NSIndent}}{{indent}}            private {{node.Value.Type}} _{{depth}}_{{node.Value.Name}};
+{{indent}}                [EditorBrowsable(EditorBrowsableState.Never)]
+{{indent}}                private {{node.Value.Type}} _{{depth}}_{{node.Value.Name}};
 
-{{NSIndent}}{{indent}}            public {{node.Value.Type}} Get() => _{{depth}}_{{node.Value.Name}} ??=
-{{NSIndent}}{{indent}}                node.GetNodeOrNull<{{node.Value.Type}}>("{{node.Value.Path}}");
+{{indent}}                public {{node.Value.Type}} Get() => _{{depth}}_{{node.Value.Name}} ??=
+{{indent}}                    node.GetNodeOrNull<{{node.Value.Type}}>("{{node.Value.Path}}");
 
-{{NSIndent}}{{indent}}            public static implicit operator {{node.Value.Type}}(__{{depth}}_{{node.Value.Name}} source)
-{{NSIndent}}{{indent}}                => source.Get();
+{{indent}}                public static implicit operator {{node.Value.Type}}(__{{depth}}_{{node.Value.Name}} source)
+{{indent}}                    => source.Get();
 {{~
     for child in node.Children | array.filter @visible
         render_tree child depth + 1 indent + "    "
     end
 ~}}
-{{NSIndent}}{{indent}}        }
+{{indent}}            }
 {{~ end -}}
 
 {{-
@@ -72,53 +66,23 @@ end
 
 using System.ComponentModel;
 
-{{~NSOpen~}}
-{{NSIndent}}partial class {{ClassName}}
-{{NSIndent}}{
+namespace GodotSharp.SourceGenerators.SceneTreeExtensions {
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    class {{SceneTreeClassName}}
+    {
 {{~
 for node in UniqueNodes
     render_unique node
 end
 ~}}
-{{NSIndent}}    [EditorBrowsable(EditorBrowsableState.Never)]
-{{NSIndent}}    private _SceneTree _sceneTree;
+        private readonly Godot.Node node;
 
-{{NSIndent}}    private _SceneTree _ => _sceneTree ??= new(GetSceneRoot());
-
-{{NSIndent}}    private Godot.Node GetSceneRoot()
-{{NSIndent}}    {
-{{NSIndent}}        Godot.Node sceneRootEstimate = this;
-{{NSIndent}}        while (true)
-{{NSIndent}}        {
-{{NSIndent}}            if (sceneRootEstimate.SceneFilePath == "{{TscnFile}}")
-{{NSIndent}}            {
-{{NSIndent}}                return sceneRootEstimate;
-{{NSIndent}}            }
-{{NSIndent}}
-{{NSIndent}}            if (sceneRootEstimate.GetParent() is not { } newSceneRootEstimate)
-{{NSIndent}}            {
-{{NSIndent}}                Throw($"Expected {sceneRootEstimate} to have a parent.");
-{{NSIndent}}            }
-{{NSIndent}}            sceneRootEstimate = newSceneRootEstimate;
-{{NSIndent}}        }
-
-{{NSIndent}}        static void Throw(string message) {
-{{NSIndent}}            throw new System.InvalidOperationException($"Could not find root of scene {{ TscnFile }} in the instantiated tree. {message} This error might be caused by using {{ClassName}} outside of {{TscnFile}}.");
-{{NSIndent}}        }
-{{NSIndent}}    }
-
-{{NSIndent}}    [EditorBrowsable(EditorBrowsableState.Never)]
-{{NSIndent}}    private class _SceneTree
-{{NSIndent}}    {
-{{NSIndent}}        private readonly Godot.Node node;
-
-{{NSIndent}}        public _SceneTree(Godot.Node node)
-{{NSIndent}}            => this.node = node;
+        public {{SceneTreeClassName}}(Godot.Node node)
+        => this.node = node;
 {{~
 for node in SceneTree.Children | array.filter @visible
     render_tree node
 end
 ~}}
-{{NSIndent}}    }
-{{NSIndent}}}
-{{~NSClose~}}
+    }
+}

--- a/SourceGenerators/SceneTreeExtensions/SceneTreeTemplate.sbncs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeTemplate.sbncs
@@ -66,9 +66,10 @@ end
 
 using System.ComponentModel;
 
-namespace GodotSharp.SourceGenerators.SceneTreeExtensions {
+namespace {{Namespace}}
+{
     [EditorBrowsable(EditorBrowsableState.Never)]
-    class {{SceneTreeClassName}}
+    class {{ClassName}}
     {
 {{~
 for node in UniqueNodes
@@ -77,7 +78,7 @@ end
 ~}}
         private readonly Godot.Node node;
 
-        public {{SceneTreeClassName}}(Godot.Node node)
+        public {{ClassName}}(Godot.Node node)
         => this.node = node;
 {{~
 for node in SceneTree.Children | array.filter @visible

--- a/SourceGenerators/SourceGeneratorForDeclaredFieldWithAttribute.cs
+++ b/SourceGenerators/SourceGeneratorForDeclaredFieldWithAttribute.cs
@@ -7,8 +7,13 @@ namespace GodotSharp.SourceGenerators
     public abstract class SourceGeneratorForDeclaredFieldWithAttribute<TAttribute> : SourceGeneratorForDeclaredMemberWithAttribute<TAttribute, FieldDeclarationSyntax>
         where TAttribute : Attribute
     {
-        protected abstract (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, IFieldSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options);
-        protected sealed override (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, ISymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
+        protected abstract CodeGenerationResult GenerateCode(
+            Compilation compilation,
+            SyntaxNode node,
+            IFieldSymbol symbol,
+            AttributeData attribute,
+            AnalyzerConfigOptions options);
+        protected sealed override CodeGenerationResult GenerateCode(Compilation compilation, SyntaxNode node, ISymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
             => GenerateCode(compilation, node, (IFieldSymbol)symbol, attribute, options);
 
         protected override SyntaxNode Node(FieldDeclarationSyntax node)

--- a/SourceGenerators/SourceGeneratorForDeclaredMemberWithAttribute.cs
+++ b/SourceGenerators/SourceGeneratorForDeclaredMemberWithAttribute.cs
@@ -1,21 +1,27 @@
 ﻿using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using GeneratorContext = Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext;
 
 namespace GodotSharp.SourceGenerators
 {
-    public abstract class SourceGeneratorForDeclaredMemberWithAttribute<TAttribute, TDeclarationSyntax> : IIncrementalGenerator
+    public abstract class
+        SourceGeneratorForDeclaredMemberWithAttribute<TAttribute, TDeclarationSyntax> : IIncrementalGenerator
         where TAttribute : Attribute
         where TDeclarationSyntax : MemberDeclarationSyntax
     {
         private static readonly string attributeType = typeof(TAttribute).Name;
-        private static readonly string attributeName = Regex.Replace(attributeType, "Attribute$", "", RegexOptions.Compiled);
 
-        protected virtual IEnumerable<(string Name, string Source)> StaticSources => Enumerable.Empty<(string Name, string Source)>();
+        private static readonly string attributeName = Regex.Replace(
+            attributeType,
+            "Attribute$",
+            "",
+            RegexOptions.Compiled);
+
+        protected virtual IEnumerable<(string Name, string Source)> StaticSources =>
+            Enumerable.Empty<(string Name, string Source)>();
 
         public void Initialize(GeneratorContext context)
         {
@@ -23,8 +29,11 @@ namespace GodotSharp.SourceGenerators
                 context.RegisterPostInitializationOutput(x => x.AddSource($"{name}.g.cs", source));
 
             var syntaxProvider = context.SyntaxProvider.CreateSyntaxProvider(IsSyntaxTarget, GetSyntaxTarget);
-            var compilationProvider = context.CompilationProvider.Combine(syntaxProvider.Collect()).Combine(context.AnalyzerConfigOptionsProvider);
-            context.RegisterImplementationSourceOutput(compilationProvider, (context, provider) => OnExecute(context, provider.Left.Left, provider.Left.Right, provider.Right));
+            var compilationProvider = context.CompilationProvider.Combine(syntaxProvider.Collect())
+                .Combine(context.AnalyzerConfigOptionsProvider);
+            context.RegisterImplementationSourceOutput(
+                compilationProvider,
+                (context, provider) => OnExecute(context, provider.Left.Left, provider.Left.Right, provider.Right));
 
             static bool IsSyntaxTarget(SyntaxNode node, CancellationToken _)
             {
@@ -50,10 +59,15 @@ namespace GodotSharp.SourceGenerators
             static TDeclarationSyntax GetSyntaxTarget(GeneratorSyntaxContext context, CancellationToken _)
                 => (TDeclarationSyntax)context.Node;
 
-            void OnExecute(SourceProductionContext context, Compilation compilation, ImmutableArray<TDeclarationSyntax> nodes, AnalyzerConfigOptionsProvider options)
+            void OnExecute(
+                SourceProductionContext context,
+                Compilation compilation,
+                ImmutableArray<TDeclarationSyntax> nodes,
+                AnalyzerConfigOptionsProvider options)
             {
                 try
                 {
+                    var unresolvedDependencies = new Queue<CodeDependency>();
                     foreach (var node in nodes.Distinct())
                     {
                         if (context.CancellationToken.IsCancellationRequested)
@@ -61,20 +75,60 @@ namespace GodotSharp.SourceGenerators
 
                         var model = compilation.GetSemanticModel(node.SyntaxTree);
                         var symbol = model.GetDeclaredSymbol(Node(node));
-                        var attribute = symbol.GetAttributes().SingleOrDefault(x => x.AttributeClass.Name == attributeType);
+                        var attribute = symbol.GetAttributes()
+                            .SingleOrDefault(x => x.AttributeClass.Name == attributeType);
                         if (attribute is null) continue;
 
-                        var (generatedCode, error) = _GenerateCode(compilation, node, symbol, attribute, options.GlobalOptions);
+                        var result = _GenerateCode(compilation, node, symbol, attribute, options.GlobalOptions);
 
-                        if (generatedCode is null)
+                        switch (result)
                         {
-                            var descriptor = new DiagnosticDescriptor(error.Id ?? attributeName, error.Title, error.Message, error.Category ?? "Usage", DiagnosticSeverity.Error, true);
-                            var diagnostic = Diagnostic.Create(descriptor, attribute.ApplicationSyntaxReference.GetSyntax().GetLocation());
-                            context.ReportDiagnostic(diagnostic);
+                            case CodeGenerationResult.Error { Detail: var detail }:
+                                var descriptor = new DiagnosticDescriptor(
+                                    detail.Id ?? attributeName,
+                                    detail.Title,
+                                    detail.Message,
+                                    detail.Category ?? "Usage",
+                                    DiagnosticSeverity.Error,
+                                    true);
+                                var diagnostic = Diagnostic.Create(
+                                    descriptor,
+                                    attribute.ApplicationSyntaxReference.GetSyntax().GetLocation());
+                                context.ReportDiagnostic(diagnostic);
+                                continue;
+                            case CodeGenerationResult.Success
+                            {
+                                Code: var generatedCode, Dependencies: var dependencies
+                            }:
+                                context.AddSource(GenerateFilename(symbol), generatedCode);
+                                foreach (var d in dependencies)
+                                {
+                                    unresolvedDependencies.Enqueue(d);
+                                }
+
+                                continue;
+                            default:
+                                throw new InvalidOperationException(
+                                    $"Unexpected code generation result {result.GetType().Name}.");
+                        }
+                    }
+
+
+                    var resolvedDependencies = new HashSet<CodeDependency>();
+                    var resolver = new DependencyResolver();
+                    while (unresolvedDependencies.TryDequeue(out var dependency))
+                    {
+                        if (resolvedDependencies.Contains(dependency))
+                        {
                             continue;
                         }
 
-                        context.AddSource(GenerateFilename(symbol), generatedCode);
+                        var newDependencies = resolver.ResolveDependency(context, compilation, dependency);
+                        resolvedDependencies.Add(dependency);
+                        foreach (var newDependency in newDependencies)
+                        {
+                            unresolvedDependencies.Enqueue(newDependency);
+                        }
                     }
                 }
                 catch (Exception e)
@@ -85,9 +139,19 @@ namespace GodotSharp.SourceGenerators
             }
         }
 
-        protected abstract (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, ISymbol symbol, AttributeData attribute, AnalyzerConfigOptions options);
+        protected abstract CodeGenerationResult GenerateCode(
+            Compilation compilation,
+            SyntaxNode node,
+            ISymbol symbol,
+            AttributeData attribute,
+            AnalyzerConfigOptions options);
 
-        private (string GeneratedCode, DiagnosticDetail Error) _GenerateCode(Compilation compilation, SyntaxNode node, ISymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
+        private CodeGenerationResult _GenerateCode(
+            Compilation compilation,
+            SyntaxNode node,
+            ISymbol symbol,
+            AttributeData attribute,
+            AnalyzerConfigOptions options)
         {
             try
             {
@@ -96,7 +160,7 @@ namespace GodotSharp.SourceGenerators
             catch (Exception e)
             {
                 Log.Error(e);
-                return (null, InternalError(e));
+                return new CodeGenerationResult.Error(InternalError(e));
             }
 
             static DiagnosticDetail InternalError(Exception e)
@@ -105,6 +169,7 @@ namespace GodotSharp.SourceGenerators
 
         private const string Ext = ".g.cs";
         private const int MaxFileLength = 255;
+
         protected virtual string GenerateFilename(ISymbol symbol)
         {
             var gn = $"{Format(symbol)}{Ext}";
@@ -120,11 +185,10 @@ namespace GodotSharp.SourceGenerators
 
         private static readonly char[] InvalidFileNameChars = new char[]
         {
-            '\"', '<', '>', '|', '\0',
-            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,
-            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20,
-            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
-            (char)31, ':', '*', '?', '\\', '/'
+            '\"', '<', '>', '|', '\0', (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8,
+            (char)9, (char)10, (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18,
+            (char)19, (char)20, (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28,
+            (char)29, (char)30, (char)31, ':', '*', '?', '\\', '/'
         };
     }
 }

--- a/SourceGenerators/SourceGeneratorForDeclaredMethodWithAttribute.cs
+++ b/SourceGenerators/SourceGeneratorForDeclaredMethodWithAttribute.cs
@@ -7,8 +7,8 @@ namespace GodotSharp.SourceGenerators
     public abstract class SourceGeneratorForDeclaredMethodWithAttribute<TAttribute> : SourceGeneratorForDeclaredMemberWithAttribute<TAttribute, MethodDeclarationSyntax>
         where TAttribute : Attribute
     {
-        protected abstract (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, IMethodSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options);
-        protected sealed override (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, ISymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
+        protected abstract CodeGenerationResult GenerateCode(Compilation compilation, SyntaxNode node, IMethodSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options);
+        protected sealed override CodeGenerationResult GenerateCode(Compilation compilation, SyntaxNode node, ISymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
             => GenerateCode(compilation, node, (IMethodSymbol)symbol, attribute, options);
     }
 }

--- a/SourceGenerators/SourceGeneratorForDeclaredPropertyWithAttribute.cs
+++ b/SourceGenerators/SourceGeneratorForDeclaredPropertyWithAttribute.cs
@@ -7,8 +7,13 @@ namespace GodotSharp.SourceGenerators
     public abstract class SourceGeneratorForDeclaredPropertyWithAttribute<TAttribute> : SourceGeneratorForDeclaredMemberWithAttribute<TAttribute, PropertyDeclarationSyntax>
         where TAttribute : Attribute
     {
-        protected abstract (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, IPropertySymbol symbol, AttributeData attribute, AnalyzerConfigOptions options);
-        protected sealed override (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, ISymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
+        protected abstract CodeGenerationResult GenerateCode(
+            Compilation compilation,
+            SyntaxNode node,
+            IPropertySymbol symbol,
+            AttributeData attribute,
+            AnalyzerConfigOptions options);
+        protected sealed override CodeGenerationResult GenerateCode(Compilation compilation, SyntaxNode node, ISymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
             => GenerateCode(compilation, node, (IPropertySymbol)symbol, attribute, options);
     }
 }

--- a/SourceGenerators/SourceGeneratorForDeclaredTypeWithAttribute.cs
+++ b/SourceGenerators/SourceGeneratorForDeclaredTypeWithAttribute.cs
@@ -7,8 +7,18 @@ namespace GodotSharp.SourceGenerators
     public abstract class SourceGeneratorForDeclaredTypeWithAttribute<TAttribute> : SourceGeneratorForDeclaredMemberWithAttribute<TAttribute, TypeDeclarationSyntax>
         where TAttribute : Attribute
     {
-        protected abstract (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, INamedTypeSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options);
-        protected sealed override (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, ISymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
+        protected abstract CodeGenerationResult GenerateCode(
+            Compilation compilation,
+            SyntaxNode node,
+            INamedTypeSymbol symbol,
+            AttributeData attribute,
+            AnalyzerConfigOptions options);
+        protected sealed override CodeGenerationResult GenerateCode(
+            Compilation compilation,
+            SyntaxNode node,
+            ISymbol symbol,
+            AttributeData attribute,
+            AnalyzerConfigOptions options)
             => GenerateCode(compilation, node, (INamedTypeSymbol)symbol, attribute, options);
     }
 }

--- a/SourceGenerators/SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators.csproj
@@ -100,8 +100,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/Cat-Lips/GodotSharp.SourceGenerators</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Cat-Lips/GodotSharp.SourceGenerators</PackageProjectUrl>
-    <Version>2.4.1-$([System.DateTime]::Now.ToString(yyMMdd-HHmm)).$(Configuration)</Version>
-    <!--<Version>2.4.0</Version>-->
+    <Version>2.5.0-accessSceneTreeFromDescendantNodes-rc.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" Link="Package\docs\README.md" />

--- a/SourceGenerators/SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>GodotSharp.SourceGenerators</AssemblyName>
     <RootNamespace>GodotSharp.SourceGenerators</RootNamespace>

--- a/SourceGenerators/SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators.csproj
@@ -100,7 +100,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/Cat-Lips/GodotSharp.SourceGenerators</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Cat-Lips/GodotSharp.SourceGenerators</PackageProjectUrl>
-    <Version>2.5.0-accessSceneTreeFromDescendantNodes-rc.2</Version>
+    <Version>2.4.1-$([System.DateTime]::Now.ToString(yyMMdd-HHmm)).$(Configuration)</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" Link="Package\docs\README.md" />

--- a/SourceGenerators/SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators.csproj
@@ -101,6 +101,7 @@
     <RepositoryUrl>https://github.com/Cat-Lips/GodotSharp.SourceGenerators</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Cat-Lips/GodotSharp.SourceGenerators</PackageProjectUrl>
     <Version>2.4.1-$([System.DateTime]::Now.ToString(yyMMdd-HHmm)).$(Configuration)</Version>
+    <!--<Version>2.4.0</Version>-->
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" Link="Package\docs\README.md" />


### PR DESCRIPTION
With the introduction of [SceneTree] on descendant nodes, we do not want to generate the SceneTree class for each consumer. Instead, it should only be generated once and reused.