### PR TITLE
Add [Notify] for partial auto-properties.

### DIFF
--- a/SourceGenerators/GodotNotifyExtensions/GodotNotifyDataModel.cs
+++ b/SourceGenerators/GodotNotifyExtensions/GodotNotifyDataModel.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace GodotSharp.SourceGenerators.GodotNotifyExtensions
 {
@@ -10,14 +12,30 @@ namespace GodotSharp.SourceGenerators.GodotNotifyExtensions
         public bool ClassIsResource { get; }
         public bool ValueIsResource { get; }
         public bool ValueIsResourceArray { get; }
+        public bool IsPartial { get; }
+        public bool ImplicitGetMethod { get; }
+        public bool ImplicitSetMethod { get; }
+        public string GetMethodAccess { get; }
+        public string SetMethodAccess { get; }
+        public string Modifiers { get; }
 
-        public GodotNotifyDataModel(IPropertySymbol property)
+        public GodotNotifyDataModel(IPropertySymbol property, SyntaxNode node)
             : base(property)
         {
             Type = property.Type.ToString();
             Name = property.Name;
             Field = $"{char.ToLower(Name[0])}{Name[1..]}";
             ClassIsResource = IsResource(property.ContainingType);
+            Modifiers = "";
+            if (HasPartialModifier(node, out var modifiers))
+            {
+                IsPartial = true;
+                Modifiers = modifiers;
+                ImplicitGetMethod = property.GetMethod?.IsImplicitlyDeclared ?? false;
+                ImplicitSetMethod = property.SetMethod?.IsImplicitlyDeclared ?? false;
+                GetMethodAccess = AccessString(property.GetMethod);
+                SetMethodAccess = AccessString(property.SetMethod);
+            }
             if (property.Type is IArrayTypeSymbol arrayType)
                 ValueIsResourceArray = IsResource(arrayType.ElementType);
             else
@@ -25,6 +43,24 @@ namespace GodotSharp.SourceGenerators.GodotNotifyExtensions
 
             static bool IsResource(ITypeSymbol type)
                 => type.InheritsFrom("Resource");
+
+            static bool HasPartialModifier(SyntaxNode node, out string modifiers)
+            {
+                if (node is not PropertyDeclarationSyntax dec)
+                {
+                    modifiers = "";
+                    return false;
+                }
+                var ret = dec.Modifiers.Any(token => token.ValueText == "partial");
+                modifiers = dec.Modifiers.ToString();
+                return ret;
+            }
+
+            static string AccessString(IMethodSymbol symbol)
+            {
+                var value = SyntaxFacts.GetText(symbol?.DeclaredAccessibility ?? Accessibility.NotApplicable) ?? "";
+                return value.Length > 0 ? value + " " : value;
+            }
         }
 
         protected override string Str()
@@ -40,6 +76,10 @@ namespace GodotSharp.SourceGenerators.GodotNotifyExtensions
                     if (ClassIsResource) yield return ", Parent Class is Resource";
                     if (ValueIsResource) yield return ", Value Type is Resource";
                     if (ValueIsResourceArray) yield return ", Value Type is Resource Array";
+                    if (IsPartial) yield return ", IsPartial";
+                    if (ImplicitGetMethod) yield return ", GetMethod is Implicit";
+                    if (ImplicitSetMethod) yield return ", SetMethod is Implicit";
+                    if (Modifiers.Length > 0) yield return $", Modifiers are \"{Modifiers}\"";
                 }
             }
         }

--- a/SourceGenerators/GodotNotifyExtensions/GodotNotifySourceGenerator.cs
+++ b/SourceGenerators/GodotNotifyExtensions/GodotNotifySourceGenerator.cs
@@ -12,7 +12,7 @@ namespace GodotSharp.SourceGenerators.GodotNotifyExtensions
 
         protected override (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, IPropertySymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
         {
-            var model = new GodotNotifyDataModel(symbol);
+            var model = new GodotNotifyDataModel(symbol, node);
             Log.Debug($"--- MODEL ---\n{model}\n");
 
             var output = GodotNotifyTemplate.Render(model, member => member.Name);

--- a/SourceGenerators/GodotNotifyExtensions/GodotNotifyTemplate.sbncs
+++ b/SourceGenerators/GodotNotifyExtensions/GodotNotifyTemplate.sbncs
@@ -20,6 +20,20 @@ using Godot;
 {{NSIndent}}    private void Init{{Name}}({{Type}} value)
 {{NSIndent}}        => __{{Field}} ??= new(this, value);
 
+{{~ if IsPartial && (ImplicitGetMethod || ImplicitSetMethod) ~}}
+#if NET9_0_OR_GREATER
+{{NSIndent}}    {{Modifiers}} {{Type}} {{Name}}
+{{NSIndent}}    {
+{{~ if ImplicitGetMethod ~}}
+{{NSIndent}}         {{GetMethodAccess}}get => _{{Field}}.Get();
+{{~ end ~}}
+{{~ if ImplicitSetMethod ~}}
+{{NSIndent}}         {{SetMethodAccess}}set => _{{Field}}.Set(value);
+{{~ end ~}}
+{{NSIndent}}    }
+#endif
+{{~ end ~}}
+
 {{NSIndent}}    [EditorBrowsable(EditorBrowsableState.Never)]
 {{NSIndent}}    private class __GodotNotify{{Name}}
 {{NSIndent}}    {


### PR DESCRIPTION
This (in theory) allows you to use .NET 9's partial auto-properties to generate default behavior. 

A declaration like so:

```cs
public partial class MyNode : Node
{
    // Minimal example
    [Notify]
    public partial float Value1 { get; set; }
    
    // Complex example:
    // - Additional modifiers are preserved (like "virtual").
    // - Access modifiers of get/set are preserved ("protected get;").
    // - Omitted implementations are likewise omitted in the output (no "set").
    [Notify]
    public partial virtual float Value2 { protected get; }
}
```

Should generate this:

```cs
// Minimal example
#if NET9_0_OR_GREATER
    public partial float Value1
    {
        get => _value1.Get();
        set => _value1.Set(value);
    }
#endif

// Complex example
#if NET9_0_OR_GREATER
    public partial virtual float Value2
    {
        protected get => _value2.Get();
    }
#endif
```

Unfortunately, it's not clear to me how I'm supposed to actually *test* the implementation nor how I might write, build, & execute a formal test class/scene to verify the behavior. Was hoping you could provide guidance on that or review/verify the implementation yourself.