### PR TITLE
Use ; not { }

### DIFF
--- a/CustomGeneratorTests/MyClassAttribute.cs
+++ b/CustomGeneratorTests/MyClassAttribute.cs
@@ -3,4 +3,4 @@
 namespace CustomGeneratorTests;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class MyClassAttribute : Attribute { }
+public class MyClassAttribute : Attribute;

--- a/CustomGeneratorTests/MyMethodAttribute.cs
+++ b/CustomGeneratorTests/MyMethodAttribute.cs
@@ -3,4 +3,4 @@
 namespace CustomGeneratorTests;
 
 [AttributeUsage(AttributeTargets.Method)]
-public class MyMethodAttribute : Attribute { }
+public class MyMethodAttribute : Attribute;

--- a/Godot 3 Tests/TestScenes/Feature59.InputMapAttribute/MyInput.cs
+++ b/Godot 3 Tests/TestScenes/Feature59.InputMapAttribute/MyInput.cs
@@ -3,7 +3,7 @@
 namespace GodotTests.TestScenes;
 
 [InputMap]
-public partial class MyInput { }
+public partial class MyInput;
 
 [InputMap]
-public static partial class MyStaticInput { }
+public static partial class MyStaticInput;

--- a/Godot 3 Tests/TestScenes/Feature59.LayerNamesAttribute/MyLayers.cs
+++ b/Godot 3 Tests/TestScenes/Feature59.LayerNamesAttribute/MyLayers.cs
@@ -3,7 +3,7 @@
 namespace GodotTests.TestScenes;
 
 [LayerNames]
-public partial class MyLayers { }
+public partial class MyLayers;
 
 [LayerNames]
-public static partial class MyStaticLayers { }
+public static partial class MyStaticLayers;

--- a/Godot 3 Tests/TestScenes/Issue15.EditableChildren/MyLabel.cs
+++ b/Godot 3 Tests/TestScenes/Issue15.EditableChildren/MyLabel.cs
@@ -2,4 +2,4 @@ using Godot;
 
 namespace GodotTests.TestScenes;
 
-internal abstract partial class MyLabel : Label { }
+internal abstract partial class MyLabel : Label;

--- a/Godot 4 Tests/TestScenes/Feature59.InputMapAttribute/MyInput.cs
+++ b/Godot 4 Tests/TestScenes/Feature59.InputMapAttribute/MyInput.cs
@@ -3,7 +3,7 @@
 namespace GodotTests.TestScenes;
 
 [InputMap]
-public partial class MyInput { }
+public partial class MyInput;
 
 [InputMap]
-public static partial class MyStaticInput { }
+public static partial class MyStaticInput;

--- a/Godot 4 Tests/TestScenes/Feature59.LayerNamesAttribute/MyLayers.cs
+++ b/Godot 4 Tests/TestScenes/Feature59.LayerNamesAttribute/MyLayers.cs
@@ -3,7 +3,7 @@
 namespace GodotTests.TestScenes;
 
 [LayerNames]
-public partial class MyLayers { }
+public partial class MyLayers;
 
 [LayerNames]
-public static partial class MyStaticLayers { }
+public static partial class MyStaticLayers;

--- a/Godot 4 Tests/TestScenes/Issue15.EditableChildren/MyLabel.cs
+++ b/Godot 4 Tests/TestScenes/Issue15.EditableChildren/MyLabel.cs
@@ -2,4 +2,4 @@ using Godot;
 
 namespace GodotTests.TestScenes;
 
-internal partial class MyLabel : Label { }
+internal partial class MyLabel : Label;

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ public partial class NotifyTest : Node
   * If you want access to built-in actions, see [BuiltinInputActions.cs](https://gist.github.com/qwe321qwe321qwe321/bbf4b135c49372746e45246b364378c4)
 ```cs
 [InputMap]
-public static partial class MyInput { }
+public static partial class MyInput;
 ```
 Equivalent (for defined input actions) to:
 ```cs
@@ -202,7 +202,7 @@ partial static class MyInput
   * Provides strongly typed access to layer names defined in godot.project (set via editor)
 ```cs
 [LayerNames]
-public static partial class MyLayers { }
+public static partial class MyLayers;
 ```
 Equivalent (for defined layers) to:
 ```cs
@@ -256,7 +256,7 @@ namespace Godot;
 
 [AutoloadRename("UtilsGD", "gd_utils")]
 [AutoloadRename("UtilsCS", "cs_utils")]
-static partial class Autoload { }
+static partial class Autoload;
 ```
 The following class is generated:
 ```cs


### PR DESCRIPTION
Very small change but use `;` not `{ }` when the class is empty.
```cs
public class MyClassAttribute : Attribute;
```