### PR TITLE
Use better preprocessor defines

### DIFF
--- a/SourceGenerators/GodotOverrideExtensions/GodotOverrideTemplate.sbncs
+++ b/SourceGenerators/GodotOverrideExtensions/GodotOverrideTemplate.sbncs
@@ -7,7 +7,7 @@ using Godot;
 {{NSIndent}}partial class {{ClassName}}
 {{NSIndent}}{
 {{NSIndent}}    [EditorBrowsable(EditorBrowsableState.Never)]
-#if NET6_0_OR_GREATER // Godot 4
+#if GODOT4_OR_GREATER
 {{NSIndent}}    public override partial {{ReturnType}} _{{MethodName}}({{MethodArgs}})
 #else
 {{NSIndent}}    public override {{ if Partial }}partial {{ end }}{{ReturnType}} _{{MethodName}}({{MethodArgs}})

--- a/SourceGenerators/InputMapExtensions/InputMapTemplate.sbncs
+++ b/SourceGenerators/InputMapExtensions/InputMapTemplate.sbncs
@@ -8,7 +8,7 @@ using Godot;
 {{NSIndent}}{
 {{~ for action in Actions ~}}
 {{NSIndent}}    /// <summary>The strongly typed input action name that corresponds to the <c>{{action.Item2}}</c> defined in <c>godot.project</c>.</summary>
-#if NET6_0_OR_GREATER // Godot 4
+#if GODOT4_OR_GREATER
 {{NSIndent}}    public static readonly StringName {{action.Item1}} = "{{action.Item2}}";
 #else
 {{NSIndent}}    public static readonly string {{action.Item1}} = "{{action.Item2}}";
@@ -19,7 +19,7 @@ using Godot;
 {{NSIndent}}    {
 {{~ for action in lookup ~}}
 {{NSIndent}}        /// <summary>The strongly typed input action name that corresponds to the <c>{{lookup.Key}}.{{action.Item2}}</c> defined in <c>godot.project</c>.</summary>
-#if NET6_0_OR_GREATER // Godot 4
+#if GODOT4_OR_GREATER
 {{NSIndent}}        public static readonly StringName {{action.Item1}} = "{{action.Item2}}";
 #else
 {{NSIndent}}        public static readonly string {{action.Item1}} = "{{action.Item2}}";

--- a/SourceGenerators/OnImportExtensions/Resources.cs
+++ b/SourceGenerators/OnImportExtensions/Resources.cs
@@ -9,7 +9,7 @@ internal static class Resources
 
     public static readonly string HintAttribute = @"
 #if GODOT
-#if NET6_0_OR_GREATER // Godot 4 only
+#if GODOT4_OR_GREATER
 using System;
 
 namespace Godot
@@ -32,7 +32,7 @@ namespace Godot
 
     public static readonly string OnImportEditorPlugin = @"
 #if GODOT && TOOLS
-#if NET6_0_OR_GREATER // Godot 4 only
+#if GODOT4_OR_GREATER
 using Godot.Collections;
 
 namespace Godot

--- a/SourceGenerators/OnInstantiateExtensions/OnInstantiateTemplate.sbncs
+++ b/SourceGenerators/OnInstantiateExtensions/OnInstantiateTemplate.sbncs
@@ -18,7 +18,7 @@ using Godot;
 {{NSIndent}}    public static new {{ClassName}} Instantiate({{MethodArgs}})
 #pragma warning restore CS0109 // Restore warning about redundant 'new' keyword
 {{NSIndent}}    {
-#if NET6_0_OR_GREATER // Godot 4
+#if GODOT4_OR_GREATER
 {{NSIndent}}        var scene = __Scene__.Instantiate<{{ClassName}}>();
 #else
 {{NSIndent}}        var scene = __Scene__.Instance<{{ClassName}}>();

--- a/SourceGenerators/SceneTreeExtensions/SceneTreeTemplate.sbncs
+++ b/SourceGenerators/SceneTreeExtensions/SceneTreeTemplate.sbncs
@@ -96,7 +96,7 @@ end
 {{NSIndent}}            {
 {{NSIndent}}                while (true)
 {{NSIndent}}                {
-#if NET6_0_OR_GREATER // Godot 4
+#if GODOT4_OR_GREATER
 {{NSIndent}}                    if (source.SceneFilePath is "{{TscnResource}}")
 #else
 {{NSIndent}}                    if (source.Filename is "{{TscnResource}}")


### PR DESCRIPTION
This pull request replaces the preprocessor defines used to check for Godot 4 to make it clearer and more robust.

You can see that the define exists in the docs and my editor screenshot:
https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/c_sharp_features.html#full-list-of-defines
![image](https://github.com/user-attachments/assets/2ee6cb9b-42e0-4093-bce1-d6f66e93c9da)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated conditional compilation checks throughout the codebase to use a Godot-specific version symbol instead of a general .NET version symbol. This ensures compatibility and clearer targeting of Godot 4 or greater features.

- **Chores**
	- Improved consistency in version checks across templates and resource strings for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->