### PR TITLE
Resource Tree Generator

### DIFF
--- a/SourceGenerators/ResourceTreeExtensions/ResourceTreeAttribute.cs
+++ b/SourceGenerators/ResourceTreeExtensions/ResourceTreeAttribute.cs
@@ -1,0 +1,4 @@
+﻿namespace Godot;
+
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class ResourceTreeAttribute : Attribute;

--- a/SourceGenerators/ResourceTreeExtensions/ResourceTreeDataModel.cs
+++ b/SourceGenerators/ResourceTreeExtensions/ResourceTreeDataModel.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace GodotSharp.SourceGenerators.ResourceTreeExtensions;
+
+internal class ResourceTreeDataModel : ClassDataModel
+{
+    public Tree<ResourceTreeNode> SceneTree { get; }
+
+    public ResourceTreeDataModel(Compilation compilation, INamedTypeSymbol symbol, string godotProjectDir) : base(symbol)
+    {
+        SceneTree = ResourceTreeScraper.GetNodes(compilation, symbol.Name, godotProjectDir);
+    }
+
+    protected override string Str()
+    {
+        return $"Tree:-\n{SceneTree.ToString().TrimEnd()}";
+    }
+}

--- a/SourceGenerators/ResourceTreeExtensions/ResourceTreeLeafNode.cs
+++ b/SourceGenerators/ResourceTreeExtensions/ResourceTreeLeafNode.cs
@@ -1,0 +1,16 @@
+﻿namespace GodotSharp.SourceGenerators.ResourceTreeExtensions;
+
+internal class ResourceTreeLeafNode : ResourceTreeNode
+{
+    public string Type { get; set; }
+    public string Path { get; init; }
+
+    public ResourceTreeLeafNode(string name, string type, string path) : base(name)
+    {
+        Type = type;
+        Path = path;
+    }
+
+    public override string ToString()
+        => $"Name: {Name}, Type: {Type}, Path: {Path}";
+}

--- a/SourceGenerators/ResourceTreeExtensions/ResourceTreeNode.cs
+++ b/SourceGenerators/ResourceTreeExtensions/ResourceTreeNode.cs
@@ -1,0 +1,14 @@
+﻿namespace GodotSharp.SourceGenerators.ResourceTreeExtensions;
+
+internal class ResourceTreeNode
+{
+    public string Name { get; init; }
+
+    public ResourceTreeNode(string name)
+    {
+        Name = name;
+    }
+
+    public override string ToString()
+        => $"Name: {Name}";
+}

--- a/SourceGenerators/ResourceTreeExtensions/ResourceTreeScraper.cs
+++ b/SourceGenerators/ResourceTreeExtensions/ResourceTreeScraper.cs
@@ -1,0 +1,104 @@
+﻿using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+
+namespace GodotSharp.SourceGenerators.ResourceTreeExtensions;
+
+internal static class ResourceTreeScraper
+{
+    private const string ImportFileTypeRegexStr = @"^type=""(?<Type>.*?)""$";
+    private const string TResTypeRegexStr = @"^\[gd_resource type=""(?<Type>.*?)""";
+    private const string InvalidIdentifierRegexStr = @"[^\p{Cf}\p{L}\p{Mc}\p{Mn}\p{Nd}\p{Nl}\p{Pc}]";
+    private const string InvalidIdentifierStartRegexStr = @"^[^\p{L}\p{Nl}_]";
+
+    private static Regex ImportFileTypeRegex = new(ImportFileTypeRegexStr, RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+    private static Regex TResTypeFileTypeRegex = new(TResTypeRegexStr, RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+    private static Regex InvalidIdentifierRegex = new(InvalidIdentifierRegexStr, RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+    private static Regex InvalidIdentifierStartRegex = new(InvalidIdentifierStartRegexStr, RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+
+    public static Tree<ResourceTreeNode> GetNodes(Compilation compilation, string className, string gdRoot)
+    {
+        Log.Debug($"Scraping {gdRoot} for resources");
+
+        Tree<ResourceTreeNode> sceneTree = new(new(className));
+
+        ScrapeDirectory(gdRoot, sceneTree);
+
+        void ScrapeDirectory(string path, TreeNode<ResourceTreeNode> parent)
+        {
+            HashSet<string> usedNames = [parent.Value.Name];
+
+            foreach (var dir in Directory.EnumerateDirectories(path)
+                         // Exclude e.g. .godot and .vs
+                         .Where(x => !new DirectoryInfo(x).Attributes.HasFlag(FileAttributes.Hidden)))
+            {
+                var name = SanitizeName(Path.GetFileName(dir));
+                usedNames.Add(name);
+                ScrapeDirectory(dir, parent.Add(new(name)));
+            }
+
+            foreach (var file in Directory.EnumerateFiles(path))
+            {
+                if ((GetTypeFromExtension(file)
+                     ?? GetTypeFromImportFile(file)) is { } type)
+                {
+                    var name = SanitizeName(Path.GetFileNameWithoutExtension(file));
+                    if (usedNames.Contains(name))
+                    {
+                        name = SanitizeName(Path.GetFileName(file));
+                        while (usedNames.Contains(name))
+                        {
+                            name = '_' + name;
+                        }
+                    }
+                    usedNames.Add(name);
+
+                    parent.Add(new ResourceTreeLeafNode(name, type, GD.GetResourcePath(file, gdRoot)));
+                }
+
+                static string GetTypeFromExtension(string file)
+                {
+                    return Path.GetExtension(file).ToLowerInvariant() switch
+                    {
+                        ".tscn" or ".scn" => "PackedScene",
+                        ".cs" => "CSharpScript",
+                        ".gd" => "GDScript",
+                        ".tres" => TResTypeFileTypeRegex.Match(File.ReadLines(file).First()).Groups["Type"].Value,
+                        _ => null,
+                    };
+                }
+
+                static string GetTypeFromImportFile(string file)
+                {
+                    file += ".import";
+
+                    if (!File.Exists(file)) return null;
+
+                    foreach (var line in File.ReadLines(file))
+                    {
+                        var match = ImportFileTypeRegex.Match(line);
+                        if (match.Success)
+                            return match.Groups["Type"].Value;
+                    }
+
+                    return null;
+                }
+            }
+
+            string SanitizeName(string name)
+            {
+                name = InvalidIdentifierRegex.Replace(name, "_");
+
+                if (InvalidIdentifierStartRegex.IsMatch(name))
+                    name = "_" + name;
+
+                // Prevent conflicts with keywords
+                if (name.All(char.IsLower))
+                    name = char.ToUpperInvariant(name[0]) + name[1..];
+
+                return name;
+            }
+        }
+
+        return sceneTree;
+    }
+}

--- a/SourceGenerators/ResourceTreeExtensions/ResourceTreeSourceGenerator.cs
+++ b/SourceGenerators/ResourceTreeExtensions/ResourceTreeSourceGenerator.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Scriban;
+
+namespace GodotSharp.SourceGenerators.ResourceTreeExtensions;
+
+[Generator]
+internal class ResourceTreeSourceGenerator : SourceGeneratorForDeclaredTypeWithAttribute<Godot.ResourceTreeAttribute>
+{
+    private static Template ResourceTreeTemplate => field ??= Template.Parse(Resources.ResourceTreeTemplate);
+
+    protected override (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, INamedTypeSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
+    {
+        var model = new ResourceTreeDataModel(compilation, symbol, options.TryGetGodotProjectDir());
+        Log.Debug($"--- MODEL ---\n{model}\n");
+
+        var output = ResourceTreeTemplate.Render(model, member => member.Name);
+        Log.Debug($"--- OUTPUT ---\n{output}<END>\n");
+
+        return (output, null);
+    }
+}

--- a/SourceGenerators/ResourceTreeExtensions/ResourceTreeTemplate.sbncs
+++ b/SourceGenerators/ResourceTreeExtensions/ResourceTreeTemplate.sbncs
@@ -1,0 +1,40 @@
+﻿{{- func render_leaf(node, indent) ~}}
+
+{{NSIndent}}{{indent}}    public static {{node.Value.Type}} {{node.Value.Name}}
+{{NSIndent}}{{indent}}        => GD.Load<{{node.Value.Type}}>("{{node.Value.Path}}");
+{{~ end -}}
+
+{{- func render_branch(node, depth, indent) ~}}
+
+{{NSIndent}}{{indent}}    public static class {{node.Value.Name}}
+{{NSIndent}}{{indent}}    {
+{{~
+    for child in node.Children
+        render_tree child depth + 1 indent + "    "
+    end
+~}}
+{{NSIndent}}{{indent}}    }
+{{~ end -}}
+
+{{-
+func render_tree(node, depth=0, indent="")
+    if node.Value.Type
+        render_leaf node indent
+    else
+        render_branch node depth indent
+    end
+end
+-}}
+
+using Godot;
+
+{{~NSOpen~}}
+{{NSIndent}}partial class {{ClassName}}
+{{NSIndent}}{
+{{~
+for node in SceneTree.Children
+    render_tree node
+end
+~}}
+{{NSIndent}}}
+{{~NSClose~}}

--- a/SourceGenerators/ResourceTreeExtensions/Resources.cs
+++ b/SourceGenerators/ResourceTreeExtensions/Resources.cs
@@ -1,0 +1,9 @@
+﻿using System.Reflection;
+
+namespace GodotSharp.SourceGenerators.ResourceTreeExtensions;
+
+internal static class Resources
+{
+    private const string resourceTreeTemplate = "GodotSharp.SourceGenerators.ResourceTreeExtensions.ResourceTreeTemplate.sbncs";
+    public static readonly string ResourceTreeTemplate = Assembly.GetExecutingAssembly().GetEmbeddedResource(resourceTreeTemplate);
+}


### PR DESCRIPTION
Introduces the `ResourceTreeAttribute` that allows strongly typed access to all project resources.

One additional feature that might be nice to have is parsing packed scenes to have a `PackedScene<T> : PackedScene` class that offers an implicitly typed `Instantiate`, but I assume a lot of the time scene instantiations are likely to rely on the `OnInstantiateAttribute` feature anyways and the implementation complexity also isn't completely trivial for only a pretty minor benefit.

P.S.: Huge thanks for this library, it really elevates C# to the first-class status it deserves within the Godot ecosystem!!