### PR TITLE
Resource Tree Generator: Fix Resource Include Enum

### DIFF
--- a/Godot 4 Tests/TestScenes/Feature148.ResourceTree/ResourceTreeTests.cs
+++ b/Godot 4 Tests/TestScenes/Feature148.ResourceTree/ResourceTreeTests.cs
@@ -38,10 +38,10 @@ public static partial class RelativeResDir1;
 [ResourceTree("./Resources", ResG.DirPaths)]
 public static partial class RelativeResDir2;
 
-[ResourceTree("Resources", resx: ResX.All, xtras: ["csv", "cfg", "txt", "zip"])]
+[ResourceTree("Resources", resi: ResI.All, xtras: ["csv", "cfg", "txt", "zip"])]
 public static partial class ResWithTypes;
 
-[ResourceTree(resx: ResX.Scenes)]
+[ResourceTree(resi: ResI.Scenes)]
 public static partial class ResWithScenes;
 
 //[ResourceTree("Invalid")]

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ var scene3 = Instantiate<Scene3>();
   * Advanced options available as attribute arguments:
     * source: relative or absolute path (use `/` as shortcut for `res://`)
     * resg: flags to configure generated output (see examples below)
-    * resx: flags to configure extra input (see examples below)
+    * resi: flags to configure extra input (see examples below)
     * xtras: scan for other file types (eg, txt, cfg, etc)
     * xclude: directories to exclude (addons is always excluded)
 #### Examples:
@@ -255,13 +255,13 @@ var scene3 = Instantiate<Scene3>();
 //[ResourceTree(resg: ResG.LoadRes | ResG.ResPaths)]    // Generate nested type with Load method and ResPath property
 //[ResourceTree(resg: ResG.ResPaths | ResG.DirPaths)]   // Just paths
 
-//[ResourceTree(resx: ResX.Uid)]        // Include uid files (as uid string)
-//[ResourceTree(resx: ResX.Scenes)]     // Include tscn/scn files (as PackedScene)
-//[ResourceTree(resx: ResX.Scripts)]    // Include cs/gd files (as CSharpScript/GdScript)
+//[ResourceTree(resi: ResI.Uid)]        // Include uid files (as uid string)
+//[ResourceTree(resi: ResI.Scenes)]     // Include tscn/scn files (as PackedScene)
+//[ResourceTree(resi: ResI.Scripts)]    // Include cs/gd files (as CSharpScript/GdScript)
 
-//[ResourceTree(resx: ResX.All)]                        // Include all of the above
-//[ResourceTree(resx: ResX.None)]                       // Include none of the above (default)
-//[ResourceTree(resx: ResX.Scenes | ResX.Scripts)]      // Just scenes & scripts (or any combination)
+//[ResourceTree(resi: ResI.All)]                        // Include all of the above
+//[ResourceTree(resi: ResI.None)]                       // Include none of the above (default)
+//[ResourceTree(resi: ResI.Scenes | ResI.Scripts)]      // Just scenes & scripts (or any combination)
 
 //[ResourceTree(xtras: ["cfg", "txt"])] // Include file types not recognised as a Godot resource (these could match those added to export configs)
 //[ResourceTree(xclude: ["Tests"])]     // Ignore specified folders

--- a/SourceGenerators/ResourceTreeExtensions/ResourceTreeAttribute.cs
+++ b/SourceGenerators/ResourceTreeExtensions/ResourceTreeAttribute.cs
@@ -3,12 +3,12 @@
 namespace Godot;
 
 [AttributeUsage(AttributeTargets.Class)]
-public sealed class ResourceTreeAttribute(string source = null, ResG resg = ResG.LoadRes, ResX resx = ResX.None, string[] xtras = null, string[] xclude = null) : Attribute, IResourceTreeConfig
+public sealed class ResourceTreeAttribute(string source = null, ResG resg = ResG.LoadRes, ResI resi = ResI.None, string[] xtras = null, string[] xclude = null) : Attribute, IResourceTreeConfig
 {
     public string Source { get; } = source;
-    public bool Uid { get; } = (resx & ResX.Uid) != 0;
-    public bool Scenes { get; } = (resx & ResX.Scenes) != 0;
-    public bool Scripts { get; } = (resx & ResX.Scripts) != 0;
+    public bool Uid { get; } = (resi & ResI.Uid) != 0;
+    public bool Scenes { get; } = (resi & ResI.Scenes) != 0;
+    public bool Scripts { get; } = (resi & ResI.Scripts) != 0;
     public bool UseGdLoad { get; } = (resg & ResG.LoadRes) != 0;
     public bool UseResPaths { get; } = (resg & ResG.ResPaths) != 0;
     public bool ShowDirPaths { get; } = (resg & ResG.DirPaths) != 0;
@@ -16,5 +16,5 @@ public sealed class ResourceTreeAttribute(string source = null, ResG resg = ResG
     public HashSet<string> Xclude { get; } = [.. xclude ?? []];
 
     public override string ToString() => $"ResourceTreeAttribute [Source: {Source}, {((IResourceTreeConfig)this).ToString()}]";
-    string IResourceTreeConfig.ToString() => $"ResG: {resg}, ResX: {resx}, Xtras: {string.Join("|", Xtras)}, Xclude: {string.Join("|", Xclude)}";
+    string IResourceTreeConfig.ToString() => $"ResG: {resg}, ResI: {resi}, Xtras: {string.Join("|", Xtras)}, Xclude: {string.Join("|", Xclude)}";
 }

--- a/SourceGenerators/ResourceTreeExtensions/ResourceTreeConfig.cs
+++ b/SourceGenerators/ResourceTreeExtensions/ResourceTreeConfig.cs
@@ -9,8 +9,11 @@ public enum ResG
     All = LoadRes | ResPaths | DirPaths
 }
 
+/// <summary>
+/// Specify which additional types of items to include.
+/// </summary>
 [Flags]
-public enum ResX
+public enum ResI
 {
     None,
     Uid = 1,

--- a/SourceGenerators/ResourceTreeExtensions/ResourceTreeSourceGenerator.cs
+++ b/SourceGenerators/ResourceTreeExtensions/ResourceTreeSourceGenerator.cs
@@ -28,7 +28,7 @@ internal class ResourceTreeSourceGenerator : SourceGeneratorForDeclaredTypeWithA
         Godot.ResourceTreeAttribute ReconstructAttribute() => new(
             (string)attribute.ConstructorArguments[0].Value,
             (ResG)attribute.ConstructorArguments[1].Value,
-            (ResX)attribute.ConstructorArguments[2].Value,
+            (ResI)attribute.ConstructorArguments[2].Value,
             attribute.ConstructorArguments[3].Values.Args<string>(),
             attribute.ConstructorArguments[4].Values.Args<string>());
     }


### PR DESCRIPTION
This PR includes 3 independent commits/changes, please cherry-pick as needed!

1. The flag `ResX.Scripts` was 3 instead of 4, which meant it would forcefully include UIDs and scenes and vice-versa.
2. I decided to rename `ResX` to `ResI`. Without any context and after some time has passed since working on it, `ResX` parsed in my mind as `ResourceExclude`. I'm personally not a fan of the abbreviated enums in general, but I think at least `ResI` parses more naturally as `ResourceInclude`. I also added some documentation to clarify. I'm not sure if this is considered a breaking change since it's only been included in pre-releases thus far.
3. I adjusted the namespace to `GodotSharp.SourceGenerators`. I'm not sure if the current namespace was consciously decided on or just there as an unchanged default. The extension attributes always use `Godot` and the only other enum I could find (`Scope`) uses `GodotSharp.SourceGenerators`.