### PR TITLE
Allow initial values in properties with `[Notify]` attribute

### DIFF
--- a/SourceGenerators/GodotNotifyExtensions/GodotNotifyTemplate.scriban
+++ b/SourceGenerators/GodotNotifyExtensions/GodotNotifyTemplate.scriban
@@ -32,13 +32,13 @@ partial class {{ClassName}}
     {{Modifiers}} {{Type}} {{Name}}
     {
 {{~ if GetAccess ~}}
-        {{GetAccess}}get => __{{Field}} is null ? field : _{{Field}}.Get();
+        {{GetAccess}}get => __{{Field}} is null ? field! : _{{Field}}.Get();
 {{~ end ~}}
 {{~ if SetAccess ~}}
         {{SetAccess}}set
         {
             if (__{{Field}} is null)
-                __{{Field}} = new(this, field);
+                __{{Field}} = new(this, field!);
 
             _{{Field}}.Set(value);
             field = value;
@@ -92,7 +92,7 @@ partial class {{ClassName}}
 {{~ end ~}}
 
             OnDataChanging();
-            _value = value;
+            _value = value!;
             OnDataChanged();
 
             void OnDataChanging()


### PR DESCRIPTION
See issue here #180 

<img width="1035" height="421" alt="image" src="https://github.com/user-attachments/assets/80d88a08-fcfe-4837-8529-0ec193a89fc4" />

<img width="1605" height="288" alt="image" src="https://github.com/user-attachments/assets/8e100e27-5d2b-455a-9194-e868e0e9631f" />

<img width="477" height="196" alt="image" src="https://github.com/user-attachments/assets/2d3d1940-a060-4298-b385-c1d4a131a472" />
