### PR TITLE
feat: add CancellationSource class attribute

### DIFF
--- a/Godot 4 Tests/Run.cs
+++ b/Godot 4 Tests/Run.cs
@@ -21,6 +21,7 @@ public partial class Run : Control
             yield return ITest.GetTest<AutoloadExtensionTests>;
             yield return ITest.GetTest<BuiltInScriptTest>;
             yield return ITest.GetTest<CachedNodes>;
+            yield return ITest.GetTest<CancellationSourceTests>;
             yield return ITest.GetTest<DiscardWorkaroundTest>;
             yield return ITest.GetTest<EditableChildrenTest>;
             yield return ITest.GetTest<EditableChildrenWithTraversalTest>;

--- a/Godot 4 Tests/TestScenes/CancellationSource/CancellationSourceTests.cs
+++ b/Godot 4 Tests/TestScenes/CancellationSource/CancellationSourceTests.cs
@@ -1,0 +1,38 @@
+using System.Threading;
+using FluentAssertions;
+using Godot;
+using GodotSharp.BuildingBlocks.TestRunner;
+
+namespace GodotTests.TestScenes;
+
+[SceneTree]
+[CancellationSource]
+public partial class CancellationSourceTests : Node, ITest
+{
+    private CancellationToken capturedToken;
+
+    void ITest.InitTests()
+    {
+        Cts.Should().BeNull();
+    }
+
+    void ITest.EnterTests()
+    {
+        // After entering tree, CTS should be created
+        Cts.Should().NotBeNull();
+        Cts.Token.IsCancellationRequested.Should().BeFalse();
+        Cts.Token.CanBeCanceled.Should().BeTrue();
+
+        // Capture token to verify it gets cancelled on exit
+        capturedToken = Cts.Token;
+    }
+
+    void ITest.ExitTests()
+    {
+        // After exiting tree, the captured token should be cancelled
+        capturedToken.IsCancellationRequested.Should().BeTrue();
+
+        // The property should now return null
+        Cts.Should().BeNull();
+    }
+}

--- a/Godot 4 Tests/TestScenes/CancellationSource/CancellationSourceTests.cs.uid
+++ b/Godot 4 Tests/TestScenes/CancellationSource/CancellationSourceTests.cs.uid
@@ -1,0 +1,1 @@
+uid://docd60525k7es

--- a/Godot 4 Tests/TestScenes/CancellationSource/CancellationSourceTests.tscn
+++ b/Godot 4 Tests/TestScenes/CancellationSource/CancellationSourceTests.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3]
+
+[ext_resource type="Script" path="res://TestScenes/Feature.CancellationSource/CancellationSourceTests.cs" id="1"]
+
+[node name="Root" type="Node"]
+script = ExtResource("1")

--- a/NRT.Tests/GD4.NRT/TestCancellationSource.cs
+++ b/NRT.Tests/GD4.NRT/TestCancellationSource.cs
@@ -1,0 +1,6 @@
+using Godot;
+
+namespace NRT.Tests;
+
+[CancellationSource]
+public partial class TestCancellationSource : Node;

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ C# Source Generators for use with the Godot Game Engine
 * [NEW] `AutoEnum` enum/class attribute (GD4 only):
   * (enum) Generates efficient Str/Parse for enums
   * (class) Generates enum for static data classes (for editor/network use)
+* [NEW] `CancellationSource` class attribute (GD4 only):
+  * Generates a `CancellationTokenSource` property (`Cts`) on a Node
+  * Automatically creates a new source on tree enter, cancels and disposes on tree exit
+  * Handles re-entry (fresh source each time the node enters the tree)
 * `Autoload` class attribute:
   * Provide strongly typed access to autoload nodes defined in godot.project
 * `CodeComments` class attribute:
@@ -80,6 +84,7 @@ C# Source Generators for use with the Godot Game Engine
     - [`AnimNames`](#animnames)
     - [`AudioBus`](#audiobus)
     - [`AutoEnum`](#autoenum)
+    - [`CancellationSource`](#cancellationsource)
     - [`Autoload`](#autoload)
     - [`CodeComments`](#codecomments)
     - [`GlobalGroups`](#globalgroups)
@@ -403,6 +408,74 @@ var d = MapData.FromEnum(e);      // d = MapData.Outside
 
 var s = MapData.Outside.ToStr(); // s = "Outside"
 var d = MapData.FromStr(s);      // d = MapData.Outside
+```
+
+### `CancellationSource`
+  * Class attribute (GD4 only)
+  * Generates a `CancellationTokenSource` property (`Cts`) on a Node
+  * Automatically creates a new source when the node enters the tree
+  * Cancels and disposes the source when the node exits the tree
+  * Handles re-entry (fresh source each time)
+  * Uses lazy initialization to avoid constructor conflicts
+#### Examples:
+```cs
+[CancellationSource]
+public partial class MyNode : Node
+{
+    public override void _Ready()
+    {
+        DoWork(Cts.Token);
+    }
+
+    private async void DoWork(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            await DoSomethingAsync(token);
+        }
+    }
+}
+```
+Generates:
+```cs
+partial class MyNode
+{
+    private CancellationTokenSource __cancellationTokenSource;
+    private bool __cancellationSourceInitialized;
+
+    public CancellationTokenSource Cts
+    {
+        get
+        {
+            __InitCancellationSource();
+            return __cancellationTokenSource;
+        }
+    }
+
+    private void __InitCancellationSource()
+    {
+        if (__cancellationSourceInitialized) return;
+        __cancellationSourceInitialized = true;
+
+        if (IsInsideTree())
+            __cancellationTokenSource = new CancellationTokenSource();
+
+        TreeEntered += __CancellationSource_OnTreeEntered;
+        TreeExiting += __CancellationSource_OnTreeExiting;
+    }
+
+    private void __CancellationSource_OnTreeEntered()
+    {
+        __cancellationTokenSource = new CancellationTokenSource();
+    }
+
+    private void __CancellationSource_OnTreeExiting()
+    {
+        __cancellationTokenSource?.Cancel();
+        __cancellationTokenSource?.Dispose();
+        __cancellationTokenSource = null;
+    }
+}
 ```
 
 ### `Autoload`

--- a/SourceGenerators/CancellationSourceExtensions/CancellationSourceAttribute.cs
+++ b/SourceGenerators/CancellationSourceExtensions/CancellationSourceAttribute.cs
@@ -1,0 +1,4 @@
+namespace Godot;
+
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class CancellationSourceAttribute : Attribute;

--- a/SourceGenerators/CancellationSourceExtensions/CancellationSourceDataModel.cs
+++ b/SourceGenerators/CancellationSourceExtensions/CancellationSourceDataModel.cs
@@ -1,0 +1,11 @@
+using Microsoft.CodeAnalysis;
+
+namespace GodotSharp.SourceGenerators.CancellationSourceExtensions;
+
+internal class CancellationSourceDataModel(INamedTypeSymbol symbol) : ClassDataModel(symbol)
+{
+    protected override string Str()
+    {
+        return $"ClassName: {ClassName}";
+    }
+}

--- a/SourceGenerators/CancellationSourceExtensions/CancellationSourceSourceGenerator.cs
+++ b/SourceGenerators/CancellationSourceExtensions/CancellationSourceSourceGenerator.cs
@@ -1,0 +1,22 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Scriban;
+
+namespace GodotSharp.SourceGenerators.CancellationSourceExtensions;
+
+[Generator]
+internal class CancellationSourceSourceGenerator : SourceGeneratorForDeclaredTypeWithAttribute<Godot.CancellationSourceAttribute>
+{
+    private static Template CancellationSourceTemplate => field ??= Template.Parse(Resources.CancellationSourceTemplate);
+
+    protected override (string GeneratedCode, DiagnosticDetail Error) GenerateCode(Compilation compilation, SyntaxNode node, INamedTypeSymbol symbol, AttributeData attribute, AnalyzerConfigOptions options)
+    {
+        var model = new CancellationSourceDataModel(symbol);
+        Log.Debug($"--- MODEL ---\n{model}\n");
+
+        var output = CancellationSourceTemplate.Render(model, Shared.Utils);
+        Log.Debug($"--- OUTPUT ---\n{output}<END>\n");
+
+        return (output, null);
+    }
+}

--- a/SourceGenerators/CancellationSourceExtensions/CancellationSourceTemplate.scriban
+++ b/SourceGenerators/CancellationSourceExtensions/CancellationSourceTemplate.scriban
@@ -1,0 +1,49 @@
+{{-#####-CONTENT-#####-}}
+
+{{~ capture body ~}}
+    [{{EditorBrowsableNever}}]
+    private System.Threading.CancellationTokenSource __cancellationTokenSource;
+
+    [{{EditorBrowsableNever}}]
+    private bool __cancellationSourceInitialized;
+
+    public System.Threading.CancellationTokenSource Cts
+    {
+        get
+        {
+            __InitCancellationSource();
+            return __cancellationTokenSource;
+        }
+    }
+
+    [{{EditorBrowsableNever}}]
+    private void __InitCancellationSource()
+    {
+        if (__cancellationSourceInitialized) return;
+        __cancellationSourceInitialized = true;
+
+        if (IsInsideTree())
+            __cancellationTokenSource = new System.Threading.CancellationTokenSource();
+
+        TreeEntered += __CancellationSource_OnTreeEntered;
+        TreeExiting += __CancellationSource_OnTreeExiting;
+    }
+
+    [{{EditorBrowsableNever}}]
+    private void __CancellationSource_OnTreeEntered()
+    {
+        __cancellationTokenSource = new System.Threading.CancellationTokenSource();
+    }
+
+    [{{EditorBrowsableNever}}]
+    private void __CancellationSource_OnTreeExiting()
+    {
+        __cancellationTokenSource?.Cancel();
+        __cancellationTokenSource?.Dispose();
+        __cancellationTokenSource = null;
+    }
+{{~ end ~}}
+
+{{-#####-MAIN-#####-}}
+
+{{~ RenderClass body ~}}

--- a/SourceGenerators/CancellationSourceExtensions/Resources.cs
+++ b/SourceGenerators/CancellationSourceExtensions/Resources.cs
@@ -1,0 +1,9 @@
+using System.Reflection;
+
+namespace GodotSharp.SourceGenerators.CancellationSourceExtensions;
+
+internal static class Resources
+{
+    private const string cancellationSourceTemplate = "GodotSharp.SourceGenerators.CancellationSourceExtensions.CancellationSourceTemplate.scriban";
+    public static readonly string CancellationSourceTemplate = Assembly.GetExecutingAssembly().GetEmbeddedResource(cancellationSourceTemplate);
+}


### PR DESCRIPTION
This PR adds a new `CancellationSource` class attribute which adds an underlying `public CancellationTokenSource Cts` that is automatically cancelled and disposed when the node is exiting the tree. The Cts is lazily initialised and re-created when the node re-enters the tree.

I am also open to modifying this PR to use a partial property, i.e.
```csharp
[CancellationSource]
public partial CancellationTokenSource Cts { get; }
```

It seems unlikely that you would ever need more than one cancellation token source per Node, so I've gone with the class attribute approach. With that being said I can see the benefit of flexibility of being able to name the Cts whatever you want and with whatever accessibility level.

My main use case for this attribute is when I have a VFX node that may do some long running animations or tweens, and is killed early. This lets you just pass the `Cts.Token` into the tweening code and allow it to gracefully handle the disposal of the node.

I'm not super experienced with source generators in general, so open to any feedback on this one.