### PR TITLE
Use cache-less resource loading to resolve C# GC_handle crash issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,18 +175,18 @@ public void NextScene<T>() where T : ISceneTree
 public partial interface IInstantiable
 {
     static T Instantiate<T>() where T : Node, ISceneTree
-        => GD.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
+        => ResourceLoader.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
 }
 
 public partial interface IInstantiable<T> where T : Node, IInstantiable<T>, ISceneTree
 {
-    static T Instantiate() => GD.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
+    static T Instantiate() => ResourceLoader.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
 }
 
 public static partial class Instantiator
 {
     public static T Instantiate<T>() where T : Node, ISceneTree
-        => GD.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
+        => ResourceLoader.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
 }
 ```
 Usage:
@@ -612,7 +612,7 @@ Generates:
 partial class Scene1
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    private static PackedScene _Scene1 => field ??= GD.Load<PackedScene>("res://Path/To/Scene1.tscn");
+    private static PackedScene _Scene1 => field ??= ResourceLoader.Load<PackedScene>("res://Path/To/Scene1.tscn");
 
     public static Scene1 New() => (Scene1)_Scene1.Instantiate();
 
@@ -622,7 +622,7 @@ partial class Scene1
 partial class Scene2
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    private static PackedScene _Scene2 => field ??= GD.Load<PackedScene>("res://Path/To/Scene2.tscn");
+    private static PackedScene _Scene2 => field ??= ResourceLoader.Load<PackedScene>("res://Path/To/Scene2.tscn");
 
     public static Scene2 New()
     {
@@ -644,7 +644,7 @@ partial class Scene2
 partial class Scene3
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    private static PackedScene _Scene3 => field ??= GD.Load<PackedScene>("res://Path/To/Scene3.tscn");
+    private static PackedScene _Scene3 => field ??= ResourceLoader.Load<PackedScene>("res://Path/To/Scene3.tscn");
 
     public static Scene3 Instantiate(int arg1, string arg2, object arg3 = null)
     {
@@ -845,7 +845,7 @@ Generates:
 partial class MyScene
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    private static PackedScene _MyScene => field ??= GD.Load<PackedScene>("res://Path/To/MyScene.tscn");
+    private static PackedScene _MyScene => field ??= ResourceLoader.Load<PackedScene>("res://Path/To/MyScene.tscn");
 
     public static MyScene Instantiate(string myArg1, int myArg2)
     {
@@ -894,8 +894,8 @@ Usage:
 //[ResourceTree("./Assets")]            // Scan from <classpath>/Assets
 //[ResourceTree("res://Assets")]        // Scan from res://Assets
 
-//[ResourceTree(resg: ResG.LoadRes)]    // Generate strongly typed properties that call GD.Load (default)
-//[ResourceTree(resg: ResG.ResPaths)]   // Generate resource paths for files (in addition to or instead of GD.Load)
+//[ResourceTree(resg: ResG.LoadRes)]    // Generate strongly typed properties that call ResourceLoader.Load (default)
+//[ResourceTree(resg: ResG.ResPaths)]   // Generate resource paths for files (in addition to or instead of ResourceLoader.Load)
 //[ResourceTree(resg: ResG.DirPaths)]   // Generate resource paths for directories
 
 //[ResourceTree(resg: ResG.All)]                        // Everything
@@ -932,7 +932,7 @@ partial class MyRes
         public static partial class IconSvg                         // -- (Res.ResPaths | Res.Load - generates nested type)
         {
             public static string ResPath => "res://Assets/icon.svg";
-            public static CompressedTexture2D Load() => GD.Load<CompressedTexture2D>(ResPath);
+            public static CompressedTexture2D Load() => ResourceLoader.Load<CompressedTexture2D>(ResPath);
         }
 
         public static string HelpTxt => "res://Assets/Help.txt";    // -- (xtras - always generated as resource path)
@@ -944,13 +944,13 @@ partial class MyRes
             public static class TrEnTranslation                     // -- (uses importer generated files instead of raw input file)
             {
                 public static string ResPath => "res://Assets/tr/tr.en.translation";
-                public static OptimizedTranslation Load() => GD.Load<OptimizedTranslation>(ResPath);
+                public static OptimizedTranslation Load() => ResourceLoader.Load<OptimizedTranslation>(ResPath);
             }
 
             public static class TrFrTranslation
             {
                 public static string ResPath => "res://Assets/tr/tr.fr.translation";
-                public static OptimizedTranslation Load() => GD.Load<OptimizedTranslation>(ResPath);
+                public static OptimizedTranslation Load() => ResourceLoader.Load<OptimizedTranslation>(ResPath);
             }
         }
     }
@@ -962,19 +962,19 @@ partial class MyRes
         public static class MySceneTscn
         {
             public static string ResPath => "res://Scenes/MyScene.tscn";
-            public static PackedScene Load() => GD.Load<PackedScene>(ResPath);
+            public static PackedScene Load() => ResourceLoader.Load<PackedScene>(ResPath);
         }
 
         public static class MySceneGd
         {
             public static string ResPath => "res://Scenes/MyScene.gd";
-            public static GDScript Load() => GD.Load<GDScript>(ResPath);
+            public static GDScript Load() => ResourceLoader.Load<GDScript>(ResPath);
         }
 
         public static class MySceneCs
         {
             public static string ResPath => "res://Scenes/MyScene.cs";
-            public static CSharpScript Load() => GD.Load<CSharpScript>(ResPath);
+            public static CSharpScript Load() => ResourceLoader.Load<CSharpScript>(ResPath);
         }
 
         public static string MySceneCsUid => "uid://tyjsxc2njtw2";  // -- (Res.Uid)
@@ -993,12 +993,12 @@ partial class MyRes
 {
     public static partial class Assets
     {
-        public static CompressedTexture2D IconSvg => GD.Load<CompressedTexture2D>("res://Assets/icon.svg");
+        public static CompressedTexture2D IconSvg => ResourceLoader.Load<CompressedTexture2D>("res://Assets/icon.svg");
 
         public static class Tr
         {
-            public static OptimizedTranslation TrEnTranslation => GD.Load<OptimizedTranslation>("res://Assets/tr/tr.en.translation");
-            public static OptimizedTranslation TrFrTranslation => GD.Load<OptimizedTranslation>("res://Assets/tr/tr.fr.translation");
+            public static OptimizedTranslation TrEnTranslation => ResourceLoader.Load<OptimizedTranslation>("res://Assets/tr/tr.en.translation");
+            public static OptimizedTranslation TrFrTranslation => ResourceLoader.Load<OptimizedTranslation>("res://Assets/tr/tr.fr.translation");
         }
     }
 }
@@ -1090,7 +1090,7 @@ Generates:
 partial class MyShader
 {
     public const string ShaderPath = "res://Path/To/MyShader.gdshader";
-    public static Shader LoadShader() => GD.Load<Shader>(ShaderPath);
+    public static Shader LoadShader() => ResourceLoader.Load<Shader>(ShaderPath);
 
     public ShaderMaterial Material { get; private init; }
 
@@ -1154,7 +1154,7 @@ Generates:
 static partial class MyShader
 {
     public const string ShaderPath = "res://Path/To/MyShader.gdshader";
-    public static Shader LoadShader() => GD.Load<Shader>(ShaderPath);
+    public static Shader LoadShader() => ResourceLoader.Load<Shader>(ShaderPath);
     public static ShaderMaterial New() => NewMaterial();
     public static ShaderMaterial NewMaterial()
     {
@@ -1205,7 +1205,7 @@ Generates:
 partial class MyShader
 {
     public const string ShaderPath = "res://Path/To/MyShader.gdshader";
-    public static Shader LoadShader() => GD.Load<Shader>(ShaderPath);
+    public static Shader LoadShader() => ResourceLoader.Load<Shader>(ShaderPath);
 
     public MyShader()
     {
@@ -1336,7 +1336,7 @@ partial class MyNode
 
 partial class MyScene
 {
-    public static MyScene Instance { get; } = InitScene((MyScene)GD.Load<PackedScene>("res://PathTo/MyScene.tscn").Instantiate());
+    public static MyScene Instance { get; } = InitScene((MyScene)ResourceLoader.Load<PackedScene>("res://PathTo/MyScene.tscn").Instantiate());
     [EditorBrowsable(EditorBrowsableState.Never)] private static MyScene InitScene(MyScene x) { x.InitScene(); return x; }
     private MyScene() { }
 }

--- a/README.md
+++ b/README.md
@@ -175,18 +175,18 @@ public void NextScene<T>() where T : ISceneTree
 public partial interface IInstantiable
 {
     static T Instantiate<T>() where T : Node, ISceneTree
-        => ResourceLoader.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
+        => ResourceLoader.Load<PackedScene>(T.TscnFilePath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep).Instantiate<T>();
 }
 
 public partial interface IInstantiable<T> where T : Node, IInstantiable<T>, ISceneTree
 {
-    static T Instantiate() => ResourceLoader.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
+    static T Instantiate() => ResourceLoader.Load<PackedScene>(T.TscnFilePath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep).Instantiate<T>();
 }
 
 public static partial class Instantiator
 {
     public static T Instantiate<T>() where T : Node, ISceneTree
-        => ResourceLoader.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
+        => ResourceLoader.Load<PackedScene>(T.TscnFilePath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep).Instantiate<T>();
 }
 ```
 Usage:
@@ -612,7 +612,7 @@ Generates:
 partial class Scene1
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    private static PackedScene _Scene1 => field ??= ResourceLoader.Load<PackedScene>("res://Path/To/Scene1.tscn");
+    private static PackedScene _Scene1 => field ??= ResourceLoader.Load<PackedScene>("res://Path/To/Scene1.tscn", cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
 
     public static Scene1 New() => (Scene1)_Scene1.Instantiate();
 
@@ -622,7 +622,7 @@ partial class Scene1
 partial class Scene2
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    private static PackedScene _Scene2 => field ??= ResourceLoader.Load<PackedScene>("res://Path/To/Scene2.tscn");
+    private static PackedScene _Scene2 => field ??= ResourceLoader.Load<PackedScene>("res://Path/To/Scene2.tscn", cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
 
     public static Scene2 New()
     {
@@ -644,7 +644,7 @@ partial class Scene2
 partial class Scene3
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    private static PackedScene _Scene3 => field ??= ResourceLoader.Load<PackedScene>("res://Path/To/Scene3.tscn");
+    private static PackedScene _Scene3 => field ??= ResourceLoader.Load<PackedScene>("res://Path/To/Scene3.tscn", cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
 
     public static Scene3 Instantiate(int arg1, string arg2, object arg3 = null)
     {
@@ -845,7 +845,7 @@ Generates:
 partial class MyScene
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    private static PackedScene _MyScene => field ??= ResourceLoader.Load<PackedScene>("res://Path/To/MyScene.tscn");
+    private static PackedScene _MyScene => field ??= ResourceLoader.Load<PackedScene>("res://Path/To/MyScene.tscn", cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
 
     public static MyScene Instantiate(string myArg1, int myArg2)
     {
@@ -932,7 +932,7 @@ partial class MyRes
         public static partial class IconSvg                         // -- (Res.ResPaths | Res.Load - generates nested type)
         {
             public static string ResPath => "res://Assets/icon.svg";
-            public static CompressedTexture2D Load() => ResourceLoader.Load<CompressedTexture2D>(ResPath);
+            public static CompressedTexture2D Load() => ResourceLoader.Load<CompressedTexture2D>(ResPath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
         }
 
         public static string HelpTxt => "res://Assets/Help.txt";    // -- (xtras - always generated as resource path)
@@ -944,13 +944,13 @@ partial class MyRes
             public static class TrEnTranslation                     // -- (uses importer generated files instead of raw input file)
             {
                 public static string ResPath => "res://Assets/tr/tr.en.translation";
-                public static OptimizedTranslation Load() => ResourceLoader.Load<OptimizedTranslation>(ResPath);
+                public static OptimizedTranslation Load() => ResourceLoader.Load<OptimizedTranslation>(ResPath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
             }
 
             public static class TrFrTranslation
             {
                 public static string ResPath => "res://Assets/tr/tr.fr.translation";
-                public static OptimizedTranslation Load() => ResourceLoader.Load<OptimizedTranslation>(ResPath);
+                public static OptimizedTranslation Load() => ResourceLoader.Load<OptimizedTranslation>(ResPath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
             }
         }
     }
@@ -962,19 +962,19 @@ partial class MyRes
         public static class MySceneTscn
         {
             public static string ResPath => "res://Scenes/MyScene.tscn";
-            public static PackedScene Load() => ResourceLoader.Load<PackedScene>(ResPath);
+            public static PackedScene Load() => ResourceLoader.Load<PackedScene>(ResPath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
         }
 
         public static class MySceneGd
         {
             public static string ResPath => "res://Scenes/MyScene.gd";
-            public static GDScript Load() => ResourceLoader.Load<GDScript>(ResPath);
+            public static GDScript Load() => ResourceLoader.Load<GDScript>(ResPath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
         }
 
         public static class MySceneCs
         {
             public static string ResPath => "res://Scenes/MyScene.cs";
-            public static CSharpScript Load() => ResourceLoader.Load<CSharpScript>(ResPath);
+            public static CSharpScript Load() => ResourceLoader.Load<CSharpScript>(ResPath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
         }
 
         public static string MySceneCsUid => "uid://tyjsxc2njtw2";  // -- (Res.Uid)
@@ -993,12 +993,12 @@ partial class MyRes
 {
     public static partial class Assets
     {
-        public static CompressedTexture2D IconSvg => ResourceLoader.Load<CompressedTexture2D>("res://Assets/icon.svg");
+        public static CompressedTexture2D IconSvg => ResourceLoader.Load<CompressedTexture2D>("res://Assets/icon.svg", cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
 
         public static class Tr
         {
-            public static OptimizedTranslation TrEnTranslation => ResourceLoader.Load<OptimizedTranslation>("res://Assets/tr/tr.en.translation");
-            public static OptimizedTranslation TrFrTranslation => ResourceLoader.Load<OptimizedTranslation>("res://Assets/tr/tr.fr.translation");
+            public static OptimizedTranslation TrEnTranslation => ResourceLoader.Load<OptimizedTranslation>("res://Assets/tr/tr.en.translation", cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
+            public static OptimizedTranslation TrFrTranslation => ResourceLoader.Load<OptimizedTranslation>("res://Assets/tr/tr.fr.translation", cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
         }
     }
 }
@@ -1090,7 +1090,7 @@ Generates:
 partial class MyShader
 {
     public const string ShaderPath = "res://Path/To/MyShader.gdshader";
-    public static Shader LoadShader() => ResourceLoader.Load<Shader>(ShaderPath);
+    public static Shader LoadShader() => ResourceLoader.Load<Shader>(ShaderPath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
 
     public ShaderMaterial Material { get; private init; }
 
@@ -1154,7 +1154,7 @@ Generates:
 static partial class MyShader
 {
     public const string ShaderPath = "res://Path/To/MyShader.gdshader";
-    public static Shader LoadShader() => ResourceLoader.Load<Shader>(ShaderPath);
+    public static Shader LoadShader() => ResourceLoader.Load<Shader>(ShaderPath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
     public static ShaderMaterial New() => NewMaterial();
     public static ShaderMaterial NewMaterial()
     {
@@ -1205,7 +1205,7 @@ Generates:
 partial class MyShader
 {
     public const string ShaderPath = "res://Path/To/MyShader.gdshader";
-    public static Shader LoadShader() => ResourceLoader.Load<Shader>(ShaderPath);
+    public static Shader LoadShader() => ResourceLoader.Load<Shader>(ShaderPath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
 
     public MyShader()
     {
@@ -1336,7 +1336,7 @@ partial class MyNode
 
 partial class MyScene
 {
-    public static MyScene Instance { get; } = InitScene((MyScene)ResourceLoader.Load<PackedScene>("res://PathTo/MyScene.tscn").Instantiate());
+    public static MyScene Instance { get; } = InitScene((MyScene)ResourceLoader.Load<PackedScene>("res://PathTo/MyScene.tscn", cacheMode: ResourceLoader.CacheMode.IgnoreDeep).Instantiate());
     [EditorBrowsable(EditorBrowsableState.Never)] private static MyScene InitScene(MyScene x) { x.InitScene(); return x; }
     private MyScene() { }
 }

--- a/SourceGenerators/InstantiableExtensions/InstantiableTemplate.scriban
+++ b/SourceGenerators/InstantiableExtensions/InstantiableTemplate.scriban
@@ -5,7 +5,7 @@
     private static PackedScene __{{ClassName}};
 
     [{{EditorBrowsableNever}}]
-    private static PackedScene _{{ClassName}} => __{{ClassName}} ??= ResourceLoader.Load<PackedScene>("{{Tscn}}");
+    private static PackedScene _{{ClassName}} => __{{ClassName}} ??= ResourceLoader.Load<PackedScene>("{{Tscn}}", cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
 
     #nullable restore
 {{~ if InitList.empty? ~}}

--- a/SourceGenerators/InstantiableExtensions/InstantiableTemplate.scriban
+++ b/SourceGenerators/InstantiableExtensions/InstantiableTemplate.scriban
@@ -5,7 +5,7 @@
     private static PackedScene __{{ClassName}};
 
     [{{EditorBrowsableNever}}]
-    private static PackedScene _{{ClassName}} => __{{ClassName}} ??= GD.Load<PackedScene>("{{Tscn}}");
+    private static PackedScene _{{ClassName}} => __{{ClassName}} ??= ResourceLoader.Load<PackedScene>("{{Tscn}}");
 
     #nullable restore
 {{~ if InitList.empty? ~}}

--- a/SourceGenerators/OnInstantiateExtensions/OnInstantiateTemplate.scriban
+++ b/SourceGenerators/OnInstantiateExtensions/OnInstantiateTemplate.scriban
@@ -12,7 +12,7 @@ partial class {{ClassName}}
     private static PackedScene __scene__;
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    private static PackedScene __Scene__ => __scene__ ??= GD.Load<PackedScene>("{{ResourcePath}}");
+    private static PackedScene __Scene__ => __scene__ ??= ResourceLoader.Load<PackedScene>("{{ResourcePath}}");
 
 {{~ end ~}}
 #nullable restore

--- a/SourceGenerators/OnInstantiateExtensions/OnInstantiateTemplate.scriban
+++ b/SourceGenerators/OnInstantiateExtensions/OnInstantiateTemplate.scriban
@@ -12,7 +12,7 @@ partial class {{ClassName}}
     private static PackedScene __scene__;
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    private static PackedScene __Scene__ => __scene__ ??= ResourceLoader.Load<PackedScene>("{{ResourcePath}}");
+    private static PackedScene __Scene__ => __scene__ ??= ResourceLoader.Load<PackedScene>("{{ResourcePath}}", cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
 
 {{~ end ~}}
 #nullable restore

--- a/SourceGenerators/ResourceTreeExtensions/ResourceTreeTemplate.scriban
+++ b/SourceGenerators/ResourceTreeExtensions/ResourceTreeTemplate.scriban
@@ -6,10 +6,10 @@
         {{~ TAB depth}}public static class {{SAFE_NAME node depth}}
         {{~ TAB depth}}{
         {{~ TAB depth}}    public static string ResPath => "{{node.Value.Path}}";
-        {{~ TAB depth}}    public static {{node.Value.Type}} Load() => ResourceLoader.Load<{{node.Value.Type}}>(ResPath);
+        {{~ TAB depth}}    public static {{node.Value.Type}} Load() => ResourceLoader.Load<{{node.Value.Type}}>(ResPath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
         {{~ TAB depth}}}
         {{~ else ~}}
-        {{~ TAB depth}}public static {{node.Value.Type}} {{node.Value.Name}} => ResourceLoader.Load<{{node.Value.Type}}>("{{node.Value.Path}}");
+        {{~ TAB depth}}public static {{node.Value.Type}} {{node.Value.Name}} => ResourceLoader.Load<{{node.Value.Type}}>("{{node.Value.Path}}", cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
         {{~ end ~}}
     {{~ else ~}}
         {{~ if node.Value.Show ~}}

--- a/SourceGenerators/ResourceTreeExtensions/ResourceTreeTemplate.scriban
+++ b/SourceGenerators/ResourceTreeExtensions/ResourceTreeTemplate.scriban
@@ -6,10 +6,10 @@
         {{~ TAB depth}}public static class {{SAFE_NAME node depth}}
         {{~ TAB depth}}{
         {{~ TAB depth}}    public static string ResPath => "{{node.Value.Path}}";
-        {{~ TAB depth}}    public static {{node.Value.Type}} Load() => GD.Load<{{node.Value.Type}}>(ResPath);
+        {{~ TAB depth}}    public static {{node.Value.Type}} Load() => ResourceLoader.Load<{{node.Value.Type}}>(ResPath);
         {{~ TAB depth}}}
         {{~ else ~}}
-        {{~ TAB depth}}public static {{node.Value.Type}} {{node.Value.Name}} => GD.Load<{{node.Value.Type}}>("{{node.Value.Path}}");
+        {{~ TAB depth}}public static {{node.Value.Type}} {{node.Value.Name}} => ResourceLoader.Load<{{node.Value.Type}}>("{{node.Value.Path}}");
         {{~ end ~}}
     {{~ else ~}}
         {{~ if node.Value.Show ~}}

--- a/SourceGenerators/SceneTreeExtensions/Resources.cs
+++ b/SourceGenerators/SceneTreeExtensions/Resources.cs
@@ -23,19 +23,19 @@ namespace Godot;
 
 public partial interface IInstantiable<T> where T : Node, IInstantiable<T>, ISceneTree
 {
-    static T Instantiate() => GD.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
+    static T Instantiate() => ResourceLoader.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
 }
 
 public partial interface IInstantiable
 {
     static T Instantiate<T>() where T : Node, ISceneTree
-        => GD.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
+        => ResourceLoader.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
 }
 
 public static partial class Instantiator
 {
     public static T Instantiate<T>() where T : Node, ISceneTree
-        => GD.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
+        => ResourceLoader.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
 }
 #endif".Trim();
 }

--- a/SourceGenerators/SceneTreeExtensions/Resources.cs
+++ b/SourceGenerators/SceneTreeExtensions/Resources.cs
@@ -23,19 +23,19 @@ namespace Godot;
 
 public partial interface IInstantiable<T> where T : Node, IInstantiable<T>, ISceneTree
 {
-    static T Instantiate() => ResourceLoader.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
+    static T Instantiate() => ResourceLoader.Load<PackedScene>(T.TscnFilePath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep).Instantiate<T>();
 }
 
 public partial interface IInstantiable
 {
     static T Instantiate<T>() where T : Node, ISceneTree
-        => ResourceLoader.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
+        => ResourceLoader.Load<PackedScene>(T.TscnFilePath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep).Instantiate<T>();
 }
 
 public static partial class Instantiator
 {
     public static T Instantiate<T>() where T : Node, ISceneTree
-        => ResourceLoader.Load<PackedScene>(T.TscnFilePath).Instantiate<T>();
+        => ResourceLoader.Load<PackedScene>(T.TscnFilePath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep).Instantiate<T>();
 }
 #endif".Trim();
 }

--- a/SourceGenerators/ShaderExtensions/ShaderTemplate.scriban
+++ b/SourceGenerators/ShaderExtensions/ShaderTemplate.scriban
@@ -2,7 +2,7 @@
 
 {{~ func STATIC ~}}
     public const string ShaderPath = "{{ShaderPath}}";
-    public static {{ShaderType}} LoadShader() => GD.Load<{{ShaderType}}>(ShaderPath);
+    public static {{ShaderType}} LoadShader() => ResourceLoader.Load<{{ShaderType}}>(ShaderPath);
     public static ShaderMaterial New() => NewMaterial();
     public static ShaderMaterial NewMaterial()
     {
@@ -124,7 +124,7 @@
 
 {{~ func MATERIAL ~}}
     public const string ShaderPath = "{{ShaderPath}}";
-    public static {{ShaderType}} LoadShader() => GD.Load<{{ShaderType}}>(ShaderPath);
+    public static {{ShaderType}} LoadShader() => ResourceLoader.Load<{{ShaderType}}>(ShaderPath);
 
     public {{ClassName}}()
     {
@@ -233,7 +233,7 @@
 
 {{~ func OTHER ~}}
     public const string ShaderPath = "{{ShaderPath}}";
-    public static {{ShaderType}} LoadShader() => GD.Load<{{ShaderType}}>(ShaderPath);
+    public static {{ShaderType}} LoadShader() => ResourceLoader.Load<{{ShaderType}}>(ShaderPath);
 
     public ShaderMaterial Material { get; private init; }
 

--- a/SourceGenerators/ShaderExtensions/ShaderTemplate.scriban
+++ b/SourceGenerators/ShaderExtensions/ShaderTemplate.scriban
@@ -2,7 +2,7 @@
 
 {{~ func STATIC ~}}
     public const string ShaderPath = "{{ShaderPath}}";
-    public static {{ShaderType}} LoadShader() => ResourceLoader.Load<{{ShaderType}}>(ShaderPath);
+    public static {{ShaderType}} LoadShader() => ResourceLoader.Load<{{ShaderType}}>(ShaderPath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
     public static ShaderMaterial New() => NewMaterial();
     public static ShaderMaterial NewMaterial()
     {
@@ -124,7 +124,7 @@
 
 {{~ func MATERIAL ~}}
     public const string ShaderPath = "{{ShaderPath}}";
-    public static {{ShaderType}} LoadShader() => ResourceLoader.Load<{{ShaderType}}>(ShaderPath);
+    public static {{ShaderType}} LoadShader() => ResourceLoader.Load<{{ShaderType}}>(ShaderPath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
 
     public {{ClassName}}()
     {
@@ -233,7 +233,7 @@
 
 {{~ func OTHER ~}}
     public const string ShaderPath = "{{ShaderPath}}";
-    public static {{ShaderType}} LoadShader() => ResourceLoader.Load<{{ShaderType}}>(ShaderPath);
+    public static {{ShaderType}} LoadShader() => ResourceLoader.Load<{{ShaderType}}>(ShaderPath, cacheMode: ResourceLoader.CacheMode.IgnoreDeep);
 
     public ShaderMaterial Material { get; private init; }
 

--- a/SourceGenerators/ShaderGlobalsExtensions/ShaderGlobalsDataModel.cs
+++ b/SourceGenerators/ShaderGlobalsExtensions/ShaderGlobalsDataModel.cs
@@ -66,7 +66,7 @@ internal class ShaderGlobalsDataModel(INamedTypeSymbol symbol, string gdRoot) : 
             return v is null ? null : TryAsRes() ?? TryAsCtor() ?? SafeValue(v);
 
             string TryAsRes()
-                => v.StartsWith("res://") ? @$"GD.Load<{csType}>(""{v}"")" : null;
+                => v.StartsWith("res://") ? @$"ResourceLoader.Load<{csType}>(""{v}"")" : null;
 
             string TryAsCtor()
             {

--- a/SourceGenerators/ShaderGlobalsExtensions/ShaderGlobalsDataModel.cs
+++ b/SourceGenerators/ShaderGlobalsExtensions/ShaderGlobalsDataModel.cs
@@ -66,7 +66,7 @@ internal class ShaderGlobalsDataModel(INamedTypeSymbol symbol, string gdRoot) : 
             return v is null ? null : TryAsRes() ?? TryAsCtor() ?? SafeValue(v);
 
             string TryAsRes()
-                => v.StartsWith("res://") ? @$"ResourceLoader.Load<{csType}>(""{v}"")" : null;
+                => v.StartsWith("res://") ? @$"ResourceLoader.Load<{csType}>(""{v}"", cacheMode: ResourceLoader.CacheMode.IgnoreDeep)" : null;
 
             string TryAsCtor()
             {

--- a/SourceGenerators/SingletonExtensions/SingletonTemplate.scriban
+++ b/SourceGenerators/SingletonExtensions/SingletonTemplate.scriban
@@ -2,7 +2,7 @@
 
 {{- capture new -}}
 {{- if TSCN -}}
-    ({{ClassName}})ResourceLoader.Load<PackedScene>("{{TSCN}}").Instantiate()
+    ({{ClassName}})ResourceLoader.Load<PackedScene>("{{TSCN}}", cacheMode: ResourceLoader.CacheMode.IgnoreDeep).Instantiate()
 {{- else -}}
     new()
 {{- end -}}

--- a/SourceGenerators/SingletonExtensions/SingletonTemplate.scriban
+++ b/SourceGenerators/SingletonExtensions/SingletonTemplate.scriban
@@ -2,7 +2,7 @@
 
 {{- capture new -}}
 {{- if TSCN -}}
-    ({{ClassName}})GD.Load<PackedScene>("{{TSCN}}").Instantiate()
+    ({{ClassName}})ResourceLoader.Load<PackedScene>("{{TSCN}}").Instantiate()
 {{- else -}}
     new()
 {{- end -}}


### PR DESCRIPTION
Fixes #205 

This PR replaces all instances `GD.Load(...)` with `ResourceLoader.Load(..., cacheMode: IgnoreDeep)`

This appears to resolve the CTD issue however it will always load a resource from disk, never from Godot's cache (as it is the cache causing this crash). Resource loading may be slower depending on how you use ResouceTree as a result.

In the issue I linked in #205 there are some examples of a resource cache implementation, which I haven't done in this PR.

### Testing: 

`dotnet test` is passing, and it compiles & works for my actual project whilst resolving the issue. but I couldn't get the test project to work even before making my changes, so I can't confirm full coverage.